### PR TITLE
Fix issue with encoding nested keywords

### DIFF
--- a/lib/bson.ex
+++ b/lib/bson.ex
@@ -3,6 +3,10 @@ defmodule BSON do
     BSON.Encoder.encode(map)
   end
 
+  def encode([{_, _}|_] = keyword) do
+    BSON.Encoder.encode(keyword)
+  end
+
   def decode(binary) when is_binary(binary) do
     BSON.Decoder.decode(binary)
   end

--- a/lib/bson/encoder.ex
+++ b/lib/bson/encoder.ex
@@ -130,6 +130,7 @@ defmodule BSON.Encoder do
   defp type(value) when is_atom(value),     do: @type_string
   defp type(value) when is_binary(value),   do: @type_string
   defp type(value) when is_map(value),      do: @type_document
+  defp type([{_,_}|_]),                     do: @type_document
   defp type(value) when is_list(value),     do: @type_array
   defp type(value) when is_int32(value),    do: @type_int32
   defp type(value) when is_int64(value),    do: @type_int64

--- a/test/bson_test.exs
+++ b/test/bson_test.exs
@@ -118,6 +118,16 @@ defmodule BSONTest do
     assert decode(@bin20) == @map20
   end
 
+  test "keywords" do
+    keyword = [set: [title: "x"]]
+    map     = %{"set" => %{"title" => "x"}}
+    encoded = <<28, 0, 0, 0, 3, 115, 101, 116, 0, 18, 0, 0, 0, 2, 116, 105, 116, 108, 101, 0, 2, 0, 0, 0, 120, 0, 0, 0>>
+
+    assert encode(keyword) == encoded
+    assert encode(map)     == encoded
+    assert decode(encoded) == map
+  end
+
   test "encode atom" do
     assert encode(%{hello: "world"}) == @bin1
   end


### PR DESCRIPTION
Also allow keywords to be passed directly to the `BSON.encode/1` function.
