### PR TITLE
Support BSON symbol type

### DIFF
--- a/lib/bson/decoder.ex
+++ b/lib/bson/decoder.ex
@@ -61,6 +61,10 @@ defmodule BSON.Decoder do
     {%BSON.JavaScript{code: code}, rest}
   end
 
+  defp type(@type_symbol, binary) do
+    type(@type_string, binary)
+  end
+
   defp type(@type_js_scope, <<size::int32, binary::binary>>) do
     size = size - 4
     <<binary::binary(size), rest::binary>> = binary

--- a/lib/bson/utils.ex
+++ b/lib/bson/utils.ex
@@ -17,6 +17,7 @@ defmodule BSON.Utils do
       @type_null      0x0A
       @type_regex     0x0B
       @type_js        0x0D
+      @type_symbol    0x0E
       @type_js_scope  0x0F
       @type_int32     0x10
       @type_timestamp 0x11

--- a/test/bson_test.exs
+++ b/test/bson_test.exs
@@ -132,6 +132,11 @@ defmodule BSONTest do
     assert encode(%{hello: "world"}) == @bin1
   end
 
+  test "decode BSON symbol into string" do
+    encoded = <<22, 0, 0, 0, 14, 104, 101, 108, 108, 111, 0, 6, 0, 0, 0, 119, 111, 114, 108, 100, 0, 0>>
+    assert decode(encoded) == @map1
+  end
+
   defp encode(value) do
     value |> BSON.encode |> IO.iodata_to_binary
   end

--- a/test/bson_test.exs
+++ b/test/bson_test.exs
@@ -132,6 +132,10 @@ defmodule BSONTest do
     assert encode(%{hello: "world"}) == @bin1
   end
 
+  test "encode atom value" do
+    assert encode(%{"hello" => :world}) == @bin1
+  end
+
   test "decode BSON symbol into string" do
     encoded = <<22, 0, 0, 0, 14, 104, 101, 108, 108, 111, 0, 6, 0, 0, 0, 119, 111, 114, 108, 100, 0, 0>>
     assert decode(encoded) == @map1


### PR DESCRIPTION
Add support for decoding BSON symbol fields. Also, atoms will be encoded as symbols (instead of strings).
