### PR TITLE
Fix Mongo.run_command/3 to accept errors without code

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -196,8 +196,8 @@ defmodule Mongo do
         case Connection.find_one(pid, "$cmd", query, [], opts) do
           %{"ok" => 1.0} = doc ->
             {:ok, doc}
-          %{"ok" => 0.0, "errmsg" => reason, "code" => code} ->
-            {:error, %Mongo.Error{message: "run_command failed: #{reason}", code: code}}
+          %{"ok" => 0.0, "errmsg" => reason} = error ->
+            {:error, %Mongo.Error{message: "run_command failed: #{reason}", code: error["code"]}}
         end
       end)
 

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -20,6 +20,12 @@ defmodule Mongo.Test do
     :ok
   end
 
+  test "run_command with an error" do
+    assert_raise Mongo.Error, fn ->
+      Mongo.run_command(Pool, %{ drop: "unexisting-database" })
+    end
+  end
+
   test "aggregate" do
     coll = unique_name
 


### PR DESCRIPTION
Related to https://github.com/ericmj/mongodb/issues/31

Drop does not return a code when a collection does not exist and you try to drop it.
