### PR TITLE
Adding example for Mongo.update_one

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -347,6 +347,15 @@ defmodule Mongo do
   Uses MongoDB update operators to specify the updates. For more information
   please refer to the
   [MongoDB documentation](http://docs.mongodb.org/manual/reference/operator/update/)
+  
+  Example:
+
+  ```
+  Mongo.update_one MongoPool,
+    "my_test_collection",
+    %{ "filter_field": "filter_value" },
+    %{ "$set": %{ "modified_field": "new_value" } }
+  ```
 
   ## Options
 

--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -350,12 +350,10 @@ defmodule Mongo do
   
   Example:
 
-  ```
-  Mongo.update_one MongoPool,
-    "my_test_collection",
-    %{ "filter_field": "filter_value" },
-    %{ "$set": %{ "modified_field": "new_value" } }
-  ```
+      Mongo.update_one(MongoPool,
+        "my_test_collection",
+        %{"filter_field": "filter_value"},
+        %{"$set": %{"modified_field": "new_value"}})
 
   ## Options
 


### PR DESCRIPTION
I was very confused when I tried to update a document; I was sending the entire document. I hope this help other people trying to use this function as I was. Also, do you consider separating the arguments into several lines, to avoid getting a line too long is permitted by the style guide? Thank you very much for your work.
