### PR TITLE
Intoduce raising and non-raising functions

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -118,6 +118,10 @@ defmodule Mongo do
     |> map_result(&(trunc(&1["n"])))
   end
 
+  @doc """
+  Similar to `count/4` but unwraps the result and raises on error.
+  """
+  @spec count!(Pool.t, collection, BSON.document, Keyword.t) :: result!(non_neg_integer)
   def count!(pool, coll, filter, opts \\ []) do
     bangify(count(pool, coll, filter, opts))
   end
@@ -144,6 +148,9 @@ defmodule Mongo do
     |> map_result(&(&1["values"]))
   end
 
+  @doc """
+  Similar to `distinct/5` but unwraps the result and raises on error.
+  """
   @spec distinct!(Pool.t, collection, String.t | atom, BSON.document, Keyword.t) :: result!([BSON.t])
   def distinct!(pool, coll, field, filter, opts \\ []) do
     bangify(distinct(pool, coll, field, filter, opts))
@@ -211,6 +218,9 @@ defmodule Mongo do
     end)
   end
 
+  @doc """
+  Similar to `run_command/3` but unwraps the result and raises on error.
+  """
   @spec run_command!(Pool.t, BSON.document, Keyword.t) :: result!(BSON.document)
   def run_command!(pool, query, opts \\ []) do
     bangify(run_command(pool, query, opts))
@@ -234,6 +244,9 @@ defmodule Mongo do
     end)
   end
 
+  @doc """
+  Similar to `insert_one/4` but unwraps the result and raises on error.
+  """
   @spec insert_one!(Pool.t, collection, BSON.document, Keyword.t) :: result!(Mongo.InsertOneResult.t)
   def insert_one!(pool, coll, doc, opts \\ []) do
     bangify(insert_one(pool, coll, doc, opts))
@@ -269,6 +282,9 @@ defmodule Mongo do
     end)
   end
 
+  @doc """
+  Similar to `insert_many/4` but unwraps the result and raises on error.
+  """
   @spec insert_many!(Pool.t, collection, [BSON.document], Keyword.t) :: result!(Mongo.InsertManyResult.t)
   def insert_many!(pool, coll, docs, opts \\ []) do
     bangify(insert_many(pool, coll, docs, opts))
@@ -289,6 +305,9 @@ defmodule Mongo do
     end)
   end
 
+  @doc """
+  Similar to `delete_one/4` but unwraps the result and raises on error.
+  """
   @spec delete_one!(Pool.t, collection, BSON.document, Keyword.t) :: result!(Mongo.DeleteResult.t)
   def delete_one!(pool, coll, filter, opts \\ []) do
     bangify(delete_one(pool, coll, filter, opts))
@@ -309,6 +328,9 @@ defmodule Mongo do
     end)
   end
 
+  @doc """
+  Similar to `delete_many/4` but unwraps the result and raises on error.
+  """
   @spec delete_many!(Pool.t, collection, BSON.document, Keyword.t) :: result!(Mongo.DeleteResult.t)
   def delete_many!(pool, coll, filter, opts \\ []) do
     bangify(delete_many(pool, coll, filter, opts))
@@ -335,6 +357,9 @@ defmodule Mongo do
     end)
   end
 
+  @doc """
+  Similar to `replace_one/5` but unwraps the result and raises on error.
+  """
   @spec replace_one!(Pool.t, collection, BSON.document, BSON.document, Keyword.t) :: result!(Mongo.UpdateResult.t)
   def replace_one!(pool, coll, filter, replacement, opts \\ []) do
     bangify(replace_one(pool, coll, filter, replacement, opts))
@@ -372,6 +397,9 @@ defmodule Mongo do
     end)
   end
 
+  @doc """
+  Similar to `update_one/5` but unwraps the result and raises on error.
+  """
   @spec update_one!(Pool.t, collection, BSON.document, BSON.document, Keyword.t) :: result!(Mongo.UpdateResult.t)
   def update_one!(pool, coll, filter, update, opts \\ []) do
     bangify(update_one(pool, coll, filter, update, opts))
@@ -402,6 +430,9 @@ defmodule Mongo do
     end)
   end
 
+  @doc """
+  Similar to `update_many/5` but unwraps the result and raises on error.
+  """
   @spec update_many!(Pool.t, collection, BSON.document, BSON.document, Keyword.t) :: result!(Mongo.UpdateResult.t)
   def update_many!(pool, coll, filter, update, opts \\ []) do
     bangify(update_many(pool, coll, filter, update, opts))
@@ -437,6 +468,9 @@ defmodule Mongo do
     end
   end
 
+  @doc """
+  Similar to `save_one/4` but unwraps the result and raises on error.
+  """
   @spec save_one!(Pool.t, collection, BSON.document, Keyword.t) :: result!(Mongo.SaveOneResult.t)
   def save_one!(pool, coll, doc, opts \\ []) do
     bangify(save_one(pool, coll, doc, opts))

--- a/lib/mongo/error.ex
+++ b/lib/mongo/error.ex
@@ -1,3 +1,4 @@
 defmodule Mongo.Error do
+  @type t :: %Mongo.Error{__exception__: true, message: binary, code: integer}
   defexception [:message, :code]
 end

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -436,24 +436,24 @@ defmodule Mongo.Test do
     assert [_] = Mongo.find(Pool, coll, %{foo: 44}) |> Enum.to_list
   end
 
-  test "save_many ordered single" do
+  test "save_many! ordered single" do
     coll = unique_name
     id = Mongo.IdServer.new
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 0, upserted_ids: %{0 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{foo: 42}])
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 0, upserted_ids: %{0 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{foo: 42}])
     assert [_] = Mongo.find(Pool, coll, %{foo: 42}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 0, upserted_ids: %{0 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{foo: 42}])
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 0, upserted_ids: %{0 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{foo: 42}])
     assert [_, _] = Mongo.find(Pool, coll, %{foo: 42}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 1, upserted_ids: %{0 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{_id: id, foo: 43}])
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 1, upserted_ids: %{0 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{_id: id, foo: 43}])
     assert [_] = Mongo.find(Pool, coll, %{foo: 43}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 1, modified_count: 1, upserted_ids: %{}}} =
-           Mongo.save_many(Pool, coll, [%{_id: id, foo: 44}])
+    assert %Mongo.SaveManyResult{matched_count: 1, modified_count: 1, upserted_ids: %{}} =
+      Mongo.save_many!(Pool, coll, [%{_id: id, foo: 44}])
     assert [] = Mongo.find(Pool, coll, %{foo: 43}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 44}) |> Enum.to_list
   end
@@ -466,33 +466,33 @@ defmodule Mongo.Test do
     id4 = Mongo.IdServer.new
     id5 = Mongo.IdServer.new
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 0,
-                                       upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{foo: 42}, %{foo: 43}])
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 0,
+                                 upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{foo: 42}, %{foo: 43}])
     assert [_] = Mongo.find(Pool, coll, %{foo: 42}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 43}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 2,
-                                       upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{_id: id1, foo: 44}, %{_id: id2, foo: 45}])
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 2,
+                                 upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{_id: id1, foo: 44}, %{_id: id2, foo: 45}])
     assert [_] = Mongo.find(Pool, coll, %{foo: 44}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 45}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 2, modified_count: 2, upserted_ids: %{}}} =
-           Mongo.save_many(Pool, coll, [%{_id: id1, foo: 46}, %{_id: id1, foo: 46}])
+    assert %Mongo.SaveManyResult{matched_count: 2, modified_count: 2, upserted_ids: %{}} =
+      Mongo.save_many!(Pool, coll, [%{_id: id1, foo: 46}, %{_id: id1, foo: 46}])
     assert [] = Mongo.find(Pool, coll, %{foo: 44}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 46}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 1,
-                                       upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}, 2 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{foo: 47}, %{_id: id3, foo: 48}, %{foo: 49}], ordered: false)
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 1,
+                                 upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}, 2 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{foo: 47}, %{_id: id3, foo: 48}, %{foo: 49}], ordered: false)
     assert [_] = Mongo.find(Pool, coll, %{foo: 47}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 48}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 49}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 2,
-                                       upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}, 2 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{_id: id4, foo: 50}, %{foo: 51}, %{_id: id5, foo: 52}], ordered: false)
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 2,
+                                 upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}, 2 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{_id: id4, foo: 50}, %{foo: 51}, %{_id: id5, foo: 52}], ordered: false)
     assert [_] = Mongo.find(Pool, coll, %{foo: 50}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 51}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 52}) |> Enum.to_list
@@ -502,20 +502,20 @@ defmodule Mongo.Test do
     coll = unique_name
     id = Mongo.IdServer.new
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 0, upserted_ids: %{0 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{foo: 42}], ordered: false)
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 0, upserted_ids: %{0 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{foo: 42}], ordered: false)
     assert [_] = Mongo.find(Pool, coll, %{foo: 42}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 0, upserted_ids: %{0 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{foo: 42}], ordered: false)
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 0, upserted_ids: %{0 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{foo: 42}], ordered: false)
     assert [_, _] = Mongo.find(Pool, coll, %{foo: 42}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 1, upserted_ids: %{0 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{_id: id, foo: 43}], ordered: false)
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 1, upserted_ids: %{0 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{_id: id, foo: 43}], ordered: false)
     assert [_] = Mongo.find(Pool, coll, %{foo: 43}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 1, modified_count: 1, upserted_ids: %{}}} =
-           Mongo.save_many(Pool, coll, [%{_id: id, foo: 44}], ordered: false)
+    assert %Mongo.SaveManyResult{matched_count: 1, modified_count: 1, upserted_ids: %{}} =
+      Mongo.save_many!(Pool, coll, [%{_id: id, foo: 44}], ordered: false)
     assert [] = Mongo.find(Pool, coll, %{foo: 43}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 44}) |> Enum.to_list
   end
@@ -528,33 +528,33 @@ defmodule Mongo.Test do
     id4 = Mongo.IdServer.new
     id5 = Mongo.IdServer.new
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 0,
-                                       upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{foo: 42}, %{foo: 43}], ordered: false)
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 0,
+                                 upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{foo: 42}, %{foo: 43}], ordered: false)
     assert [_] = Mongo.find(Pool, coll, %{foo: 42}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 43}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 2,
-                                       upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{_id: id1, foo: 44}, %{_id: id2, foo: 45}], ordered: false)
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 2,
+                                 upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{_id: id1, foo: 44}, %{_id: id2, foo: 45}], ordered: false)
     assert [_] = Mongo.find(Pool, coll, %{foo: 44}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 45}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 2, modified_count: 2, upserted_ids: %{}}} =
-           Mongo.save_many(Pool, coll, [%{_id: id1, foo: 46}, %{_id: id1, foo: 46}], ordered: false)
+    assert %Mongo.SaveManyResult{matched_count: 2, modified_count: 2, upserted_ids: %{}} =
+      Mongo.save_many!(Pool, coll, [%{_id: id1, foo: 46}, %{_id: id1, foo: 46}], ordered: false)
     assert [] = Mongo.find(Pool, coll, %{foo: 44}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 46}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 1,
-                                       upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}, 2 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{foo: 47}, %{_id: id3, foo: 48}, %{foo: 49}], ordered: false)
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 1,
+                                 upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}, 2 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{foo: 47}, %{_id: id3, foo: 48}, %{foo: 49}], ordered: false)
     assert [_] = Mongo.find(Pool, coll, %{foo: 47}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 48}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 49}) |> Enum.to_list
 
-    assert {:ok, %Mongo.SaveManyResult{matched_count: 0, modified_count: 2,
-                                       upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}, 2 => %BSON.ObjectId{}}}} =
-           Mongo.save_many(Pool, coll, [%{_id: id4, foo: 50}, %{foo: 51}, %{_id: id5, foo: 52}], ordered: false)
+    assert %Mongo.SaveManyResult{matched_count: 0, modified_count: 2,
+                                 upserted_ids: %{0 => %BSON.ObjectId{}, 1 => %BSON.ObjectId{}, 2 => %BSON.ObjectId{}}} =
+      Mongo.save_many!(Pool, coll, [%{_id: id4, foo: 50}, %{foo: 51}, %{_id: id5, foo: 52}], ordered: false)
     assert [_] = Mongo.find(Pool, coll, %{foo: 50}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 51}) |> Enum.to_list
     assert [_] = Mongo.find(Pool, coll, %{foo: 52}) |> Enum.to_list


### PR DESCRIPTION
This introduces raising and non-raising functions for all operations in the `Mongo` module when reasonable.

Because of changes in the return value of many functions this is a breaking change.

TODO:
- [x] documentation
- [x] specs
- [x] tests
