### PR TITLE
WIP: added support for authSource

### DIFF
--- a/lib/mongo/connection.ex
+++ b/lib/mongo/connection.ex
@@ -29,6 +29,7 @@ defmodule Mongo.Connection do
     * `:database` - Database (required);
     * `:username` - Username
     * `:password` - User password
+    * `:auth_source` - Authentication Database
     * `:backoff` - Backoff time for reconnects, the first reconnect is
       instantaneous (Default: 1000)
     * `:timeout` - TCP connect and receive timeouts (Default: 5000)
@@ -171,7 +172,7 @@ defmodule Mongo.Connection do
 
     s = %{socket: nil, auth: nil, tail: nil, header: nil, queue: %{},
           request_id: 0, opts: opts, database: nil, timeout: timeout,
-          write_concern: write_concern, wire_version: nil}
+          write_concern: write_concern, wire_version: nil, auth_source: nil}
 
     s = Auth.setup(s)
     {:connect, :init, s}

--- a/lib/mongo/connection/auth.ex
+++ b/lib/mongo/connection/auth.ex
@@ -2,7 +2,7 @@ defmodule Mongo.Connection.Auth do
   @moduledoc false
 
   def setup(%{auth: nil, opts: opts} = s) do
-    database = opts[:database]
+    database = if opts[:auth_source] != nil do opts[:auth_source]; else opts[:database] end
     username = opts[:username]
     password = opts[:password]
     auth     = opts[:auth] || []

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,6 +11,7 @@ version =
 
 {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.dropDatabase()')
 {_, 0} = System.cmd("mongo", ~w'mongodb_test2 --eval db.dropDatabase()')
+{_, 0} = System.cmd("mongo", ~w'admin_test --eval db.dropDatabase()')
 
 if version < {2, 6, 0} do
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.addUser({user:"mongodb_user",pwd:"mongodb_user",roles:[]})')
@@ -18,8 +19,10 @@ if version < {2, 6, 0} do
 else
   {_, _} = System.cmd("mongo", ~w'mongodb_test --eval db.dropUser("mongodb_user")')
   {_, _} = System.cmd("mongo", ~w'mongodb_test --eval db.dropUser("mongodb_user2")')
+  {_, _} = System.cmd("mongo", ~w'admin_test --eval db.dropUser("mongodb_admin_user")')
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.createUser({user:"mongodb_user",pwd:"mongodb_user",roles:[]})')
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.createUser({user:"mongodb_user2",pwd:"mongodb_user2",roles:[]})')
+  {_, 0} = System.cmd("mongo", ~w'admin_test --eval db.createUser({user:"mongodb_admin_user",pwd:"mongodb_admin_user",roles:[{role:"readWrite",db:"mongo_test"}]})')
 end
 
 defmodule MongoTest.Case do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,7 +16,7 @@ version =
 if version < {2, 6, 0} do
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.addUser({user:"mongodb_user",pwd:"mongodb_user",roles:[]})')
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.addUser({user:"mongodb_user2",pwd:"mongodb_user2",roles:[]})')
-  {_, 0} = System.cmd("mongo", ~w'admin_test --eval db.addUser({user:"mongodb_admin_user",pwd:"mongodb_admin_user",roles:[{role:"readWrite",db:"mongo_test"}]})')
+  {_, 0} = System.cmd("mongo", ~w'admin_test --eval db.addUser({user:"mongodb_admin_user",pwd:"mongodb_admin_user",roles:[], otherDBRoles:{mongo_test: ["readWrite"]}})')
 else
   {_, _} = System.cmd("mongo", ~w'mongodb_test --eval db.dropUser("mongodb_user")')
   {_, _} = System.cmd("mongo", ~w'mongodb_test --eval db.dropUser("mongodb_user2")')

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,7 +16,7 @@ version =
 if version < {2, 6, 0} do
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.addUser({user:"mongodb_user",pwd:"mongodb_user",roles:[]})')
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.addUser({user:"mongodb_user2",pwd:"mongodb_user2",roles:[]})')
-  {_, 0} = System.cmd("mongo", ~w'admin_test --eval db.addUser({user:"mongodb_admin_user",pwd:"mongodb_admin_user",roles:[],otherDBRoles:{mongo_test:["readWrite"]}})')
+  {_, 0} = System.cmd("mongo", ~w'admin --eval db.addUser({user:"mongodb_admin_user",pwd:"mongodb_admin_user",roles:[],otherDBRoles:{mongo_test:["readWrite"]}})')
 else
   {_, _} = System.cmd("mongo", ~w'mongodb_test --eval db.dropUser("mongodb_user")')
   {_, _} = System.cmd("mongo", ~w'mongodb_test --eval db.dropUser("mongodb_user2")')

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,6 +16,7 @@ version =
 if version < {2, 6, 0} do
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.addUser({user:"mongodb_user",pwd:"mongodb_user",roles:[]})')
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.addUser({user:"mongodb_user2",pwd:"mongodb_user2",roles:[]})')
+  {_, 0} = System.cmd("mongo", ~w'admin_test --eval db.addUser({user:"mongodb_admin_user",pwd:"mongodb_admin_user",roles:[{role:"readWrite",db:"mongo_test"}]})')
 else
   {_, _} = System.cmd("mongo", ~w'mongodb_test --eval db.dropUser("mongodb_user")')
   {_, _} = System.cmd("mongo", ~w'mongodb_test --eval db.dropUser("mongodb_user2")')

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,7 +16,7 @@ version =
 if version < {2, 6, 0} do
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.addUser({user:"mongodb_user",pwd:"mongodb_user",roles:[]})')
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.addUser({user:"mongodb_user2",pwd:"mongodb_user2",roles:[]})')
-  {_, 0} = System.cmd("mongo", ~w'admin_test --eval db.addUser({user:"mongodb_admin_user",pwd:"mongodb_admin_user",roles:[], otherDBRoles:{mongo_test: ["readWrite"]}})')
+  {_, 0} = System.cmd("mongo", ~w'admin_test --eval db.addUser({user:"mongodb_admin_user",pwd:"mongodb_admin_user",roles:[],otherDBRoles:{mongo_test:["readWrite"]}})')
 else
   {_, _} = System.cmd("mongo", ~w'mongodb_test --eval db.dropUser("mongodb_user")')
   {_, _} = System.cmd("mongo", ~w'mongodb_test --eval db.dropUser("mongodb_user2")')


### PR DESCRIPTION
This pull request is to add support for the [authSource option](https://docs.mongodb.com/manual/reference/connection-string/#urioption.authSource).  The provides the name of the authentication database holding the roles for the desired user.
