### PR TITLE
Auth source

### DIFF
--- a/lib/mongo/auth.ex
+++ b/lib/mongo/auth.ex
@@ -6,8 +6,9 @@ defmodule Mongo.Auth do
     auther = mechanism(s)
 
     auth_source = opts[:auth_source]
+    wire_version = s[:wire_version]
 
-    if auth_source != nil do
+    if auth_source != nil && wire_version > 0 do
       s = Map.put(s, :database, auth_source)
     end
     Enum.find_value(auth, fn opts ->

--- a/lib/mongo/auth.ex
+++ b/lib/mongo/auth.ex
@@ -5,6 +5,11 @@ defmodule Mongo.Auth do
     auth = setup(opts)
     auther = mechanism(s)
 
+    auth_source = opts[:auth_source]
+
+    if auth_source != nil do
+      s = Map.put(s, :database, auth_source)
+    end
     Enum.find_value(auth, fn opts ->
       case auther.auth(opts, s) do
         :ok ->
@@ -12,7 +17,7 @@ defmodule Mongo.Auth do
         error ->
           error
       end
-    end) || {:ok, s}
+    end) || {:ok, Map.put(s,:database, opts[:database])}
   end
 
   defp setup(opts) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -13,6 +13,7 @@ version =
 
 {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.dropDatabase()')
 {_, 0} = System.cmd("mongo", ~w'mongodb_test2 --eval db.dropDatabase()')
+{_, 0} = System.cmd("mongo", ~w'admin_test --eval db.dropDatabase()')
 
 if version < {2, 6, 0} do
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.addUser({user:"mongodb_user",pwd:"mongodb_user",roles:[]})')
@@ -22,6 +23,7 @@ else
   {_, _} = System.cmd("mongo", ~w'mongodb_test --eval db.dropUser("mongodb_user2")')
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.createUser({user:"mongodb_user",pwd:"mongodb_user",roles:[]})')
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.createUser({user:"mongodb_user2",pwd:"mongodb_user2",roles:[]})')
+  {_, 0} = System.cmd("mongo", ~w'admin_test --eval db.createUser({user:"mongodb_admin_user",pwd:"mongodb_admin_user",roles:[{role:"readWrite",db:"mongodb_test"},{role:"read",db:"mongodb_test2"}]})')
 end
 
 defmodule MongoTest.Case do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -18,6 +18,7 @@ version =
 if version < {2, 6, 0} do
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.addUser({user:"mongodb_user",pwd:"mongodb_user",roles:[]})')
   {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.addUser({user:"mongodb_user2",pwd:"mongodb_user2",roles:[]})')
+  {_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.addUser({user:"mongodb_admin_user",pwd:"mongodb_admin_user",roles:[]})')
 else
   {_, _} = System.cmd("mongo", ~w'mongodb_test --eval db.dropUser("mongodb_user")')
   {_, _} = System.cmd("mongo", ~w'mongodb_test --eval db.dropUser("mongodb_user2")')


### PR DESCRIPTION
This pull request is to add support for the [authSource option](https://docs.mongodb.com/manual/reference/connection-string/#urioption.authSource).  The provides the name of the authentication database holding the roles for the desired user.
