### PR TITLE
Refs #59. Fix float endianness.

### DIFF
--- a/lib/bson/decoder.ex
+++ b/lib/bson/decoder.ex
@@ -7,19 +7,19 @@ defmodule BSON.Decoder do
     map
   end
 
-  defp type(@type_float, <<127, 240, 0, 0, 0, 0, 0, 0, rest::binary>>) do
+  defp type(@type_float, <<0, 0, 0, 0, 0, 0, 240::little-integer-size(8), 127::little-integer-size(8), rest::binary>>) do
     {:inf, rest}
   end
 
-  defp type(@type_float, <<255, 240, 0, 0, 0, 0, 0, 0, rest::binary>>) do
+  defp type(@type_float, <<0, 0, 0, 0, 0, 0, 240::little-integer-size(8), 255::little-integer-size(8), rest::binary>>) do
     {:"-inf", rest}
   end
 
-  defp type(@type_float, <<127, 248, 0, 0, 0, 0, 0, 0, rest::binary>>) do
+  defp type(@type_float, <<0, 0, 0, 0, 0, 0, 248::little-integer-size(8), 127::little-integer-size(8), rest::binary>>) do
     {:NaN, rest}
   end
 
-  defp type(@type_float, <<float::float64, rest::binary>>) do
+  defp type(@type_float, <<float::little-float64, rest::binary>>) do
     {float, rest}
   end
 

--- a/lib/bson/encoder.ex
+++ b/lib/bson/encoder.ex
@@ -60,13 +60,13 @@ defmodule BSON.Encoder do
     do: document(value)
 
   def encode(:inf),
-    do: <<127, 240, 0, 0, 0, 0, 0, 0>>
+    do: <<0, 0, 0, 0, 0, 0, 240::little-integer-size(8), 127::little-integer-size(8)>>
 
   def encode(:"-inf"),
-    do: <<255, 240, 0, 0, 0, 0, 0, 0>>
+    do: <<0, 0, 0, 0, 0, 0, 240::little-integer-size(8), 255::little-integer-size(8)>>
 
   def encode(:NaN),
-    do: <<127, 248, 0, 0, 0, 0, 0, 0>>
+    do: <<0, 0, 0, 0, 0, 0, 248::little-integer-size(8), 127::little-integer-size(8)>>
 
   def encode(value) when is_atom(value),
     do: encode(Atom.to_string(value))
@@ -75,7 +75,7 @@ defmodule BSON.Encoder do
     do: [<<byte_size(value)+1::int32>>, value, 0x00]
 
   def encode(value) when is_float(value),
-    do: <<value::float64>>
+    do: <<value::little-float64>>
 
   def encode(value) when is_int32(value),
     do: <<value::int32>>

--- a/test/bson_test.exs
+++ b/test/bson_test.exs
@@ -142,13 +142,13 @@ defmodule BSONTest do
   end
 
   @mapPosInf %{"a" => :inf}
-  @binPosInf <<16, 0, 0, 0, 1, 97, 0, 127, 240, 0, 0, 0, 0, 0, 0, 0>>
+  @binPosInf <<16, 0, 0, 0, 1, 97, 0, 0, 0, 0, 0, 0, 0, 240::little-integer-size(8), 127::little-integer-size(8), 0>>
 
   @mapNegInf %{"a" => :"-inf"}
-  @binNegInf <<16, 0, 0, 0, 1, 97, 0, 255, 240, 0, 0, 0, 0, 0, 0, 0>>
+  @binNegInf <<16, 0, 0, 0, 1, 97, 0, 0, 0, 0, 0, 0, 0, 240::little-integer-size(8), 255::little-integer-size(8), 0>>
 
   @mapNaN %{"a" => :NaN}
-  @binNaN <<16, 0, 0, 0, 1, 97, 0, 127, 248, 0, 0, 0, 0, 0, 0, 0>>
+  @binNaN <<16, 0, 0, 0, 1, 97, 0, 0, 0, 0, 0, 0, 0, 248::little-integer-size(8), 127::little-integer-size(8), 0>>
 
   test "decode float NaN" do
     assert decode(@binNaN) == @mapNaN


### PR DESCRIPTION
According to the BSON spec, all data types should be encoded using
little endian encoding.  This has corrected this issue for floats, but
does not attempt to do it for other encoded data types.
