### PR TITLE
Fix ets lookup for pool information

### DIFF
--- a/lib/mongo/monitor.ex
+++ b/lib/mongo/monitor.ex
@@ -29,7 +29,7 @@ defmodule Mongo.Monitor do
 
     state =
       if pool && :ets.lookup(@ets, pool) == [] do
-        :ets.insert(@ets, {:pool, version})
+        :ets.insert(@ets, {pool, version})
         ref = Process.monitor(pool)
         put_in(state.monitors[ref], pool)
       else

--- a/test/mongo/monitor_test.exs
+++ b/test/mongo/monitor_test.exs
@@ -1,0 +1,11 @@
+defmodule Mongo.MonitorTest do
+  use MongoTest.Case, async: true
+
+  test "Properly retrieve wire version" do
+    {:ok, pid} = Mongo.start_link([database: "mongodb", name: MyMongo.Pool])
+
+    Mongo.Monitor.add_conn(pid, MyMongo.Pool, 4)
+    assert Mongo.Monitor.wire_version(MyMongo.Pool) == 4
+    assert Mongo.Monitor.wire_version(pid) == 4
+  end
+end


### PR DESCRIPTION
`lib/mongo/monitor.ex wire_version/1` was always failing lookup because when `handle_call/3` for `:add_conn` was called, it would use the atom `:pool` to insert the information, but it was using the contents of the `pool` variable to retrieve the information. 
