### PR TITLE
Options defined when importing the Mongo.Pool behaviour aren't used

### DIFF
--- a/lib/mongo/pool.ex
+++ b/lib/mongo/pool.ex
@@ -26,8 +26,8 @@ defmodule Mongo.Pool do
   @type t :: module
 
   @doc false
-  defmacro __using__(opts) do
-    adapter = Keyword.fetch!(opts, :adapter)
+  defmacro __using__(options) do
+    adapter = Keyword.fetch!(options, :adapter)
 
     quote do
       # TODO: Customizable timeout
@@ -42,6 +42,8 @@ defmodule Mongo.Pool do
       @doc false
       def start_link(opts) do
         import Supervisor.Spec, warn: false
+
+        opts = Keyword.merge(unquote(options), opts)
 
         children = [
           worker(Monitor, [@monitor, @ets, opts]),


### PR DESCRIPTION
Hello,

As the documentation states, you can define connection parameters when using the Mongo.Pool behaviour, but the defined options aren't passed down to the workers:

```
iex(1)> defmodule TestPool do use Mongo.Pool, adapter: Mongo.Pool.Poolboy, hostname: "localhost", database: "testiramo"  end
iex(2)> TestPool.start_link([]19:01:18.886 [error] GenServer #PID<0.209.0> terminating
** (ArgumentError) argument error
    :erlang.iolist_size([<<0, 0, 0, 0>>, [nil, 46 | "$cmd"], <<0, 0, 0, 0, 0, 1, 0, 0, 0>>, [<<19, 0, 0, 0>>, ["", 16, ["ismaster", 0], <<1, 0, 0, 0>>], 0] | ""])
    (mongodb) lib/mongo/protocol.ex:60: Mongo.Protocol.encode/2
    (mongodb) lib/mongo/connection/utils.ex:25: Mongo.Connection.Utils.send/3
    (mongodb) lib/mongo/connection/utils.ex:8: Mongo.Connection.Utils.sync_command/3
    (mongodb) lib/mongo/connection.ex:218: Mongo.Connection.init_connection/1
    (mongodb) lib/mongo/connection.ex:197: Mongo.Connection.connect/2
    (connection) lib/connection.ex:622: Connection.enter_connect/5
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message: nil
State: %{auth: [], database: nil, opts: [backoff: 1000, port: 27017, hostname: 'localhost'], queue: %{}, request_id: 0, socket: nil, tail: nil, timeout: 5000, wire_version: nil, write_concern: [w: 1]})
```

This pull requests adds the defined behaviour (bad pun intended) 😄 
