### PR TITLE
Fixed bug: option key "max_overflow" is an :atom, not a string

### DIFF
--- a/lib/mongo/pool/poolboy.ex
+++ b/lib/mongo/pool/poolboy.ex
@@ -4,7 +4,7 @@ defmodule Mongo.Pool.Poolboy do
   """
 
   @behaviour Mongo.Pool.Adapter
-  @poolboy_opts ~w(max_overflow)
+  @poolboy_opts ~w(max_overflow)a
 
   @doc """
   Starts the poolboy pool.


### PR DESCRIPTION
The poolboy option "max_overflow" was ignored **silently** because
max_overflow is fetched by the key `:max_overflow`, not `"max_overflow"`.

The bug itself does not output any error, but the error can be reproduced when setting option as
"pool_size: 0, max_overflow: 10"

https://github.com/ericmj/mongodb/blob/master/lib/mongo/pool/poolboy.ex#L19

``` elixir

  @poolboy_opts ~w(max_overflow)
  # (omit)

  def start_link(name, opts) do
    {size, opts} = Keyword.pop(opts, :pool_size, 10)
    {pool_opts, worker_opts} = Keyword.split(opts, @poolboy_opts)
  # (omit)
  end
```
