### PR TITLE
Fix travis build +some improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: elixir
 elixir:
-  - 1.2.5
+  - 1.2.6
+  - 1.3.4
 cache:
   - apt
   - directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ cache:
   - directories:
     - ~/.mongodb
 before_install:
+  - . $HOME/.nvm/nvm.sh
+  - nvm install stable
+  - nvm use stable
   - npm install -g mongodb-version-manager
   - m use $MONGOVERSION
   - mkdir db


### PR DESCRIPTION
Hi @ericmj, I've found that after an update of `mongodb-version-manager` the Travis's version of NodeJS wasn't able to build it. So here comes the fix.

Plus, I've included a newer version of Elixir into the build.