### PR TITLE
Fixing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ def start(_type, _args) do
   import Supervisor.Spec
 
   children = [
-    worker(Mongo, [name: :mongo, database: "test", pool: DBConnection.Poolboy])
+    worker(Mongo, [[name: :mongo, database: "test", pool: DBConnection.Poolboy]])
   ]
 
   opts = [strategy: :one_for_one, name: MyApp.Supervisor]


### PR DESCRIPTION
At least in version 1.3.4 of Elixir Supervisor passes the list as different parameters. In this case the opts keyword list has to be a nested list.