### PR TITLE
implement disconnect/2

### DIFF
--- a/lib/mongo/protocol.ex
+++ b/lib/mongo/protocol.ex
@@ -50,6 +50,10 @@ defmodule Mongo.Protocol do
     end
   end
 
+  def disconnect(opts, %{socket: {:gen_tcp, pid}}) do
+    :gen_tcp.close(pid)
+  end
+
   defp maybe_ssl(opts, s) do
     if s.ssl do
       ssl(s, opts)


### PR DESCRIPTION
Fix errors like:

```
** (RuntimeError) disconnect/2 not implemented
    (mongodb) lib/db_connection.ex:323: Mongo.Protocol.disconnect/2
    (db_connection) lib/db_connection/connection.ex:178: DBConnection.Connection.disconnect/2
    (connection) lib/connection.ex:767: Connection.disconnect/3
    (stdlib) gen_server.erl:601: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:667: :gen_server.handle_msg/5
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```