### PR TITLE
fix Mongo.conn type

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -49,7 +49,7 @@ defmodule Mongo do
 
   @timeout 5000
 
-  @type conn :: DbConnection.Conn
+  @type conn :: DBConnection.conn
   @type collection :: String.t
   @opaque cursor :: Mongo.Cursor.t | Mongo.AggregationCursor.t | Mongo.SinglyCursor.t
   @type result(t) :: :ok | {:ok, t} | {:error, Mongo.Error.t}


### PR DESCRIPTION
If I'm right, `Mongo.conn` should be `DBConnection.conn`
https://github.com/elixir-ecto/db_connection/blob/master/lib/db_connection.ex#L84

