### PR TITLE
Multiple databases support with database option

### DIFF
--- a/lib/mongo/protocol/utils.ex
+++ b/lib/mongo/protocol/utils.ex
@@ -15,7 +15,7 @@ defmodule Mongo.Protocol.Utils do
   end
 
   def command(id, command, s) do
-    op = op_query(coll: namespace("$cmd", s), query: BSON.Encoder.document(command),
+    op = op_query(coll: namespace("$cmd", s, nil), query: BSON.Encoder.document(command),
                   select: "", num_skip: 0, num_return: 1, flags: [])
     case message(id, op, s) do
       {:ok, op_reply(docs: docs)} ->
@@ -109,8 +109,7 @@ defmodule Mongo.Protocol.Utils do
     {:disconnect, error, s}
   end
 
-  def namespace(coll, s, database \\ nil)
-  def namespace(coll, s, database) when is_nil(database),
+  def namespace(coll, s, nil),
     do: [s.database, ?. | coll]
   def namespace(coll, _, database),
     do: [database, ?. | coll]

--- a/lib/mongo/protocol/utils.ex
+++ b/lib/mongo/protocol/utils.ex
@@ -109,8 +109,11 @@ defmodule Mongo.Protocol.Utils do
     {:disconnect, error, s}
   end
 
-  def namespace(coll, s),
+  def namespace(coll, s, database \\ nil)
+  def namespace(coll, s, database) when is_nil(database),
     do: [s.database, ?. | coll]
+  def namespace(coll, _, database),
+    do: [database, ?. | coll]
 
   def digest(nonce, username, password) do
     :crypto.hash(:md5, [nonce, username, digest_password(username, password)])

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -461,4 +461,13 @@ defmodule Mongo.Test do
     assert %Mongo.Cursor{coll: "coll", opts: [no_cursor_timeout: true, skip: 10]} =
            Mongo.find(c.pid, "coll", %{}, skip: 10, cursor_timeout: false)
   end
+
+  test "access multiple databases", c do
+    coll = unique_name()
+
+    assert {:ok, _} = Mongo.insert_one(c.pid, coll, %{foo: 42}, database: "mongodb_test2")
+
+    assert {:ok, 1} = Mongo.count(c.pid, coll, [], database: "mongodb_test2")
+    assert {:ok, 0} = Mongo.count(c.pid, coll, [])
+ end
 end


### PR DESCRIPTION
In some case, we want to access multiple databases within one session. 
It can be a database migration task, or some team has logically separated databases in one instance for any reason. My team manually sharded databases in our rules, and it's not efficient to make a connection per each database.

In this PR, I added `opts[:database]` options to protocol commands, and it allows to access other databases.

I'm not quite sure this is the best implementation, so please advise me if you have any idea.

Thanks!
