### PR TITLE
feature: find_one

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ def start(_type, _args) do
   import Supervisor.Spec
 
   children = [
-    worker(Mongo, [name: :mongo, database: "test", pool: DBConnection.Poolboy])
+    worker(Mongo, [name: :mongo, pool: DBConnection.Poolboy])
   ]
 
   opts = [strategy: :one_for_one, name: MyApp.Supervisor]

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ def start(_type, _args) do
   import Supervisor.Spec
 
   children = [
-    worker(Mongo, [name: :mongo, pool: DBConnection.Poolboy])
+    worker(Mongo, [name: :mongo, database: "test", pool: DBConnection.Poolboy])
   ]
 
   opts = [strategy: :one_for_one, name: MyApp.Supervisor]

--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -319,7 +319,6 @@ defmodule Mongo do
     bangify(distinct(conn, coll, field, filter, opts))
   end
 
-
   @doc """
   Selects document a single document in a collection and returns either a document
   or nil.
@@ -350,7 +349,6 @@ defmodule Mongo do
     |> Enum.to_list
     |> List.first
   end
-
 
   @doc """
   Selects documents in a collection and returns a cursor for the selected

--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -344,8 +344,7 @@ defmodule Mongo do
   def find_one(conn, coll, filter, opts \\ []) do
     query = [
       {"$comment", opts[:comment]},
-      {"$maxTimeMS", opts[:max_time]},
-      {"$orderby", opts[:sort]}
+      {"$maxTimeMS", opts[:max_time]}
     ] ++ Enum.into(opts[:modifiers] || [], [])
 
     query = filter_nils(query)

--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -365,9 +365,9 @@ defmodule Mongo do
     opts = cursor_type(opts[:cursor_type]) ++ Keyword.drop(opts, drop)
     opts = [{:limit, 1} | opts]
 
-    cursor = cursor(conn, coll, query, select, opts)
-    list = Enum.to_list(cursor)
-    List.first(list)
+    cursor(conn, coll, query, select, opts)
+    |> Enum.to_list
+    |> List.first
   end
 
 

--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -321,7 +321,7 @@ defmodule Mongo do
 
 
   @doc """
-  Selects document a single document in a collection and returns either the document
+  Selects document a single document in a collection and returns either a document
   or nil.
 
   If multiple documents satisfy the query, this method returns the first document

--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -321,8 +321,8 @@ defmodule Mongo do
 
 
   @doc """
-  Selects documents in a collection and returns a cursor for the selected
-  documents.
+  Selects document a single document in a collection and returns either the document
+  or nil.
 
   If multiple documents satisfy the query, this method returns the first document
   according to the natural order which reflects the order of documents on the disk.
@@ -361,10 +361,11 @@ defmodule Mongo do
 
     select = opts[:projection]
     opts = if Keyword.get(opts, :cursor_timeout, true), do: opts, else: [{:no_cursor_timeout, true}|opts]
-    drop = ~w(comment max_time modifiers sort cursor_type projection cursor_timeout order_by)a
-    opts = cursor_type(opts[:cursor_type]) ++ Keyword.drop(opts, drop)
 
-    # Return the first element
+    drop = ~w(comment max_time modifiers sort cursor_type projection cursor_timeout order_by limit)a
+    opts = cursor_type(opts[:cursor_type]) ++ Keyword.drop(opts, drop)
+    opts = [{:limit, 1} | opts]
+
     cursor = cursor(conn, coll, query, select, opts)
     list = Enum.to_list(cursor)
     List.first(list)

--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -344,6 +344,7 @@ defmodule Mongo do
     opts =
       opts
       |> Keyword.delete(:order_by)
+      |> Keyword.delete(:sort)
       |> Keyword.put(:limit, 1)
     find(conn, coll, filter, opts)
     |> Enum.to_list

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -124,6 +124,17 @@ defmodule Mongo.Test do
       Mongo.find(c.pid, coll, %{}, sort: [foo: -1], batch_size: 2, limit: 2) |> Enum.to_list
   end
 
+  test "find_one", c do
+    coll = unique_name()
+
+    assert nil == Mongo.find_one(c.pid, coll, %{})
+
+    assert {:ok, _} = Mongo.insert_one(c.pid, coll, %{foo: 42, bar: 1})
+
+    assert %{"foo" => 42} = Mongo.find_one(c.pid, coll, %{}, batch_size: 1)
+
+  end
+
   test "find_one_and_update", c do
     coll = unique_name()
 

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -130,16 +130,13 @@ defmodule Mongo.Test do
     assert nil == Mongo.find_one(c.pid, coll, %{})
 
     assert {:ok, _} = Mongo.insert_one(c.pid, coll, %{foo: 42, bar: 1})
-
     assert %{"foo" => 42} = Mongo.find_one(c.pid, coll, %{}, batch_size: 1)
+    assert nil == Mongo.find_one(c.pid, coll, %{foo: 43})
 
     assert {:ok, _} = Mongo.insert_one(c.pid, coll, %{foo: 43})
 
-    # we should still get one
     assert %{"foo" => 42} = Mongo.find_one(c.pid, coll, %{}, batch_size: 1)
-
     assert %{"foo" => 43} != Mongo.find_one(c.pid, coll, %{}, batch_size: 1)
-
   end
 
   test "find_one_and_update", c do

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -133,6 +133,13 @@ defmodule Mongo.Test do
 
     assert %{"foo" => 42} = Mongo.find_one(c.pid, coll, %{}, batch_size: 1)
 
+    assert {:ok, _} = Mongo.insert_one(c.pid, coll, %{foo: 43})
+
+    # we should still get one
+    assert %{"foo" => 42} = Mongo.find_one(c.pid, coll, %{}, batch_size: 1)
+
+    assert %{"foo" => 43} != Mongo.find_one(c.pid, coll, %{}, batch_size: 1)
+
   end
 
   test "find_one_and_update", c do


### PR DESCRIPTION
#29 

Mongodb protocol only has find. find_one is done by just taking the first document using natural order returned from find (as per mongo documentation).

I'm not sure about the applicability of all the options. 