### PR TITLE
Conversion functions for Elixir 1.3+ native DateTimes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: elixir
 elixir:
-  - 1.2.6
   - 1.3.4
 cache:
   - apt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## v0.2.1-dev
 
+* Enhancements
+  * Add functions `BSON.DateTime.to_elixir_datetime/1` and `BSON.DateTime.from_elixir_datetime/1`
+
+* Changes
+  * Requires Elixir ~1.3
+
 ## v0.2.0 (2016-11-11)
 
 * Enhancements

--- a/lib/bson/types.ex
+++ b/lib/bson/types.ex
@@ -118,6 +118,8 @@ defmodule BSON.DateTime do
   @doc """
   Converts `BSON.DateTime` into a `{{year, month, day}, {hour, min, sec, usec}}`
   tuple.
+
+  Also see `to_elixir_datetime/1`
   """
   def to_datetime(%BSON.DateTime{utc: utc}) do
     seconds = div(utc, 1000) + @epoch
@@ -129,11 +131,34 @@ defmodule BSON.DateTime do
   @doc """
   Converts `{{year, month, day}, {hour, min, sec, usec}}` into a `BSON.DateTime`
   struct.
+
+  Also see `from_elixir_datetime/1`
   """
   def from_datetime({date, {hour, min, sec, usec}}) do
     greg_secs = :calendar.datetime_to_gregorian_seconds({date, {hour, min, sec}})
     epoch_secs = greg_secs - @epoch
     %BSON.DateTime{utc: epoch_secs * 1000 + div(usec, 1000)}
+  end
+
+  @doc """
+  Converts `BSON.DateTime` into a native Elixir `DateTime` struct.
+
+      iex> BSON.DateTime.to_elixir_datetime(%BSON.DateTime{utc: 1000})
+      %DateTime{calendar: Calendar.ISO, day: 1, hour: 0, microsecond: {0, 3}, minute: 0, month: 1, second: 1, std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0, year: 1970, zone_abbr: "UTC"}
+  """
+  def to_elixir_datetime(%BSON.DateTime{utc: unix_ms}) do
+    DateTime.from_unix!(unix_ms, :milliseconds)
+  end
+
+  @doc """
+  Converts a native Elixir `DateTime` struct into a `BSON.DateTime`
+  struct.
+
+      iex> BSON.DateTime.from_elixir_datetime(DateTime.from_unix!(1))
+      %BSON.DateTime{utc: 1000}
+  """
+  def from_elixir_datetime(%DateTime{} = datetime) do
+    %BSON.DateTime{utc: datetime |> DateTime.to_unix(:milliseconds)}
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Mongodb.Mixfile do
   def project do
     [app: :mongodb,
      version: @version,
-     elixir: "~> 1.2",
+     elixir: "~> 1.3",
      name: "Mongodb",
      deps: deps(),
      docs: docs(),

--- a/test/bson/types_test.exs
+++ b/test/bson/types_test.exs
@@ -1,5 +1,6 @@
 defmodule BSON.TypesTest do
   use ExUnit.Case, async: true
+  doctest BSON.DateTime
 
   test "inspect BSON.Binary" do
     value = %BSON.Binary{binary: <<1, 2, 3>>}


### PR DESCRIPTION
Add functions for converting between BSON.DateTime structs and Elixir 1.3+ native DateTimes.