### PR TITLE
Updated the documentation for the Mongo.find/4

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -337,7 +337,7 @@ defmodule Mongo do
       see http://docs.mongodb.org/manual/reference/operator/query-modifier/
     * `:cursor_timeout` - Set to false if cursor should not close after 10
       minutes (Default: true)
-    * `:order_by` - Sorts the results of a query in ascending or descending order
+    * `:sort` - Sorts the results of a query in ascending or descending order
     * `:projection` - Limits the fields to return for all matching document
     * `:skip` - The number of documents to skip before returning (Default: 0)
   """


### PR DESCRIPTION
As the title suggests the documentation for the `Mongo.find/4` function stated the that `:order_by` option can be passed, but in reality the `:sort` option is used.