### PR TITLE
deprecation warning updates for elixir 1.4

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -139,7 +139,7 @@ defmodule Mongo do
     wv_query = %Query{action: :wire_version}
 
     with {:ok, conn, _, _} <- select_server(topology_pid, :read, opts),
-         {:ok, version} <- DBConnection.execute(conn, wv_query, [], defaults) do
+         {:ok, version} <- DBConnection.execute(conn, wv_query, [], defaults()) do
       cursor? = version >= 1 and Keyword.get(opts, :use_cursor, true)
       opts = Keyword.drop(opts, ~w(allow_disk_use max_time use_cursor)a)
 
@@ -368,7 +368,7 @@ defmodule Mongo do
     opts = if Keyword.get(opts, :cursor_timeout, true), do: opts, else: [{:no_cursor_timeout, true}|opts]
     drop = ~w(comment max_time modifiers sort cursor_type projection cursor_timeout)a
     opts = cursor_type(opts[:cursor_type]) ++ Keyword.drop(opts, drop)
-    with {:ok, conn, slave_ok, _} <- select_server(topology_pid, :read, opts),
+    with {:ok, _conn, slave_ok, _} <- select_server(topology_pid, :read, opts),
          opts = Keyword.put(opts, :slave_ok, slave_ok),
          do: cursor(topology_pid, coll, query, select, opts)
   end

--- a/lib/mongo/monitor.ex
+++ b/lib/mongo/monitor.ex
@@ -34,7 +34,7 @@ defmodule Mongo.Monitor do
       |> Keyword.put(:database, "admin")
       |> Keyword.put(:skip_auth, true)
     {:ok, pid} = DBConnection.start_link(Mongo.Protocol, opts)
-    :ok = GenServer.cast(self, :check)
+    :ok = GenServer.cast(self(), :check)
     {:ok, %{
       connection_pid: pid,
       topology_pid: topology_pid,

--- a/lib/mongo/topology_description.ex
+++ b/lib/mongo/topology_description.ex
@@ -11,8 +11,8 @@ defmodule Mongo.TopologyDescription do
   alias Mongo.ReadPreference
 
   # see https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#topologydescription
-  @type type :: :"unknown()" | :"single()" | :"replica_set_no_primary()" |
-                :"replica_set_with_primary()" | :"sharded()"
+  @type type :: :unknown | :single | :replica_set_no_primary |
+                :replica_set_with_primary | :sharded
   @type t :: %{
     type: type,
     set_name: String.t | nil,

--- a/lib/mongo/topology_description.ex
+++ b/lib/mongo/topology_description.ex
@@ -11,8 +11,8 @@ defmodule Mongo.TopologyDescription do
   alias Mongo.ReadPreference
 
   # see https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#topologydescription
-  @type type :: :unknown | :single | :replica_set_no_primary |
-                :replica_set_with_primary | :sharded
+  @type type :: :"unknown()" | :"single()" | :"replica_set_no_primary()" |
+                :"replica_set_with_primary()" | :"sharded()"
   @type t :: %{
     type: type,
     set_name: String.t | nil,
@@ -256,7 +256,7 @@ defmodule Mongo.TopologyDescription do
       address = server_description.address
       old_description = topology.servers[address]
 
-      {actions, topology} = ret =
+      {actions, topology} =
         topology
         |> put_in([:servers, address], server_description)
         |> update_topology(topology.type, server_description, num_seeds)
@@ -541,18 +541,4 @@ defmodule Mongo.TopologyDescription do
     end
   end
 
-  # invalid state checks to use before returning the state
-
-  defp check_topology(topo) do
-    cond do
-      invalid_set_name?(topo) ->
-        :invalid_set_name
-      true ->
-        :ok
-    end
-  end
-
-  defp invalid_set_name?(topo) do
-    topo.type == :single and topo.set_name != topo.servers[0].set_name
-  end
 end

--- a/test/mongo/topology_description_test.exs
+++ b/test/mongo/topology_description_test.exs
@@ -10,16 +10,16 @@ defmodule Mongo.TopologyDescriptionTest do
       read_preference: ReadPreference.defaults(%{mode: :secondary})
     ]
     assert {:ok, single_server, true, false} ==
-           TopologyDescription.select_servers(single, :read, opts)
+           TopologyDescription.select_servers(single(), :read, opts)
 
     assert {:ok, single_server, false, false} ==
-           TopologyDescription.select_servers(single, :write)
+           TopologyDescription.select_servers(single(), :write)
 
     opts = [
       read_preference: ReadPreference.defaults(%{mode: :nearest})
     ]
     assert {:ok, single_server, true, false} ==
-           TopologyDescription.select_servers(single, :read, opts)
+           TopologyDescription.select_servers(single(), :read, opts)
   end
 
   test "replica set server selection" do
@@ -30,33 +30,33 @@ defmodule Mongo.TopologyDescriptionTest do
       read_preference: ReadPreference.defaults(%{mode: :secondary})
     ]
     assert {:ok, List.delete(all_hosts, master), true, false} ==
-           TopologyDescription.select_servers(repl_set_with_master, :read, opts)
+           TopologyDescription.select_servers(repl_set_with_master(), :read, opts)
 
     opts = [
       read_preference: ReadPreference.defaults(%{mode: :primary})
     ]
     assert {:ok, [master], true, false} ==
-           TopologyDescription.select_servers(repl_set_with_master, :read, opts)
+           TopologyDescription.select_servers(repl_set_with_master(), :read, opts)
 
     opts = [
       read_preference: ReadPreference.defaults(%{mode: :nearest})
     ]
     assert {:ok, all_hosts, true, false} ==
-           TopologyDescription.select_servers(repl_set_with_master, :read, opts)
+           TopologyDescription.select_servers(repl_set_with_master(), :read, opts)
 
     opts = [
       read_preference: ReadPreference.defaults(%{mode: :secondary})
     ]
     assert {:ok, List.delete(all_hosts, master), true, false} ==
-           TopologyDescription.select_servers(repl_set_no_master, :read, opts)
+           TopologyDescription.select_servers(repl_set_no_master(), :read, opts)
 
     assert {:ok, [], false, false} ==
-           TopologyDescription.select_servers(repl_set_no_master, :write)
+           TopologyDescription.select_servers(repl_set_no_master(), :write)
 
     opts = [
       read_preference: ReadPreference.defaults(%{mode: :nearest})
     ]
     assert {:ok, all_hosts, true, false} ==
-           TopologyDescription.select_servers(repl_set_no_master, :read, opts)
+           TopologyDescription.select_servers(repl_set_no_master(), :read, opts)
   end
 end

--- a/test/mongo/topology_test.exs
+++ b/test/mongo/topology_test.exs
@@ -1,6 +1,6 @@
 defmodule Mongo.TopologyTest do
   use ExUnit.Case # DO NOT MAKE ASYNCHRONOUS
-  alias Mongoman.{ReplicaSet, ReplicaSetConfig}
+  # alias Mongoman.{ReplicaSet, ReplicaSetConfig}
 
   setup_all do
     assert {:ok, pid} = Mongo.TestConnection.connect

--- a/test/mongo/topology_test.exs
+++ b/test/mongo/topology_test.exs
@@ -1,6 +1,5 @@
 defmodule Mongo.TopologyTest do
   use ExUnit.Case # DO NOT MAKE ASYNCHRONOUS
-  # alias Mongoman.{ReplicaSet, ReplicaSetConfig}
 
   setup_all do
     assert {:ok, pid} = Mongo.TestConnection.connect

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -488,6 +488,8 @@ defmodule Mongo.Test do
   test "access multiple databases", c do
     coll = unique_name()
 
+    Mongo.delete_many(c.pid, coll, %{}, database: "mongodb_test2")
+
     assert {:ok, _} = Mongo.insert_one(c.pid, coll, %{foo: 42}, database: "mongodb_test2")
 
     assert {:ok, 1} = Mongo.count(c.pid, coll, [], database: "mongodb_test2")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -10,8 +10,8 @@ ExUnit.start()
 
 IO.puts "[mongod v#{version}]"
 
-{_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.dropDatabase() --port 27017')
-{_, 0} = System.cmd("mongo", ~w'mongodb_test2 --eval db.dropDatabase() --port 27017')
+{_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.dropDatabase() --port 27001')
+{_, 0} = System.cmd("mongo", ~w'mongodb_test2 --eval db.dropDatabase() --port 27001')
 
 version =
   version

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -10,8 +10,8 @@ ExUnit.start()
 
 IO.puts "[mongod v#{version}]"
 
-{_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.dropDatabase() --port 27001')
-{_, 0} = System.cmd("mongo", ~w'mongodb_test2 --eval db.dropDatabase() --port 27001')
+{_, 0} = System.cmd("mongo", ~w'mongodb_test --eval db.dropDatabase() --port 27017')
+{_, 0} = System.cmd("mongo", ~w'mongodb_test2 --eval db.dropDatabase() --port 27017')
 
 version =
   version


### PR DESCRIPTION
- Removing warnings: "please use parentheses to remove the ambiguity or change the variable name"
- Changed mongo default port to 27017 (for testing)
