### PR TITLE
Add BSON NaN inserted from mongojs

### DIFF
--- a/lib/bson/decoder.ex
+++ b/lib/bson/decoder.ex
@@ -28,6 +28,10 @@ defmodule BSON.Decoder do
     {:NaN, rest}
   end
 
+  defp type(@type_float, <<1, 0, 0, 0, 0, 0, 240::little-integer-size(8), 127::little-integer-size(8), rest::binary>>) do
+    {:NaN, rest}
+  end
+
   defp type(@type_float, <<float::little-float64, rest::binary>>) do
     {float, rest}
   end

--- a/test/bson_test.exs
+++ b/test/bson_test.exs
@@ -149,9 +149,11 @@ defmodule BSONTest do
 
   @mapNaN %{"a" => :NaN}
   @binNaN <<16, 0, 0, 0, 1, 97, 0, 0, 0, 0, 0, 0, 0, 248::little-integer-size(8), 127::little-integer-size(8), 0>>
+  @binNaN2 <<16, 0, 0, 0, 1, 97, 0, 1, 0, 0, 0, 0, 0, 240::little-integer-size(8), 127::little-integer-size(8), 0>>
 
   test "decode float NaN" do
     assert decode(@binNaN) == @mapNaN
+    assert decode(@binNaN2) == @mapNaN
   end
 
   test "encode float NaN" do


### PR DESCRIPTION
ref #50 

While parsing data from a mongodb 3.0.14 server
```
** (FunctionClauseError) no function clause matching in BSON.Decoder.type/2
          (mongodb) lib/bson/decoder.ex:19: BSON.Decoder.type(1, <<1, 0, 0, 0, 0, 0, 240, 127, 1, 109, 105, 108, 0, 1, 0, 0, 0, 0, 0, 240, 127, 8, 105, 103, 110, 0, 1, 8, 114, 116, 116, 0, 0, 9, 97, 116, 0, 176, 43, 230, 52, 93, 1, 0, 0, 4, 116, 97, 103, 115, ...>>)
```