### PR TITLE
fix #197

### DIFF
--- a/lib/mongo/protocol.ex
+++ b/lib/mongo/protocol.ex
@@ -92,7 +92,7 @@ defmodule Mongo.Protocol do
   defp tcp_connect(opts, s) do
     host      = (opts[:hostname] || "localhost") |> to_charlist
     port      = opts[:port] || 27017
-    sock_opts = [:binary, active: false, packet: :raw, send_timeout: s.timeout, nodelay: true]
+    sock_opts = [:binary, active: false, packet: :raw, nodelay: true]
                 ++ (opts[:socket_options] || [])
 
     s = Map.put(s, :host, "#{host}:#{port}")


### PR DESCRIPTION
Remove the `:send_timeout` option from the socket