### PR TITLE
Add missing case clause in Mongo.Protocol.connect/2

### DIFF
--- a/lib/mongo/protocol.ex
+++ b/lib/mongo/protocol.ex
@@ -58,6 +58,8 @@ defmodule Mongo.Protocol do
         {:error, Mongo.Error.exception(tag: :tcp, action: "recv", reason: reason)}
       {:disconnect, {:tcp_send, reason}, _s} ->
         {:error, Mongo.Error.exception(tag: :tcp, action: "send", reason: reason)}
+      {:disconnect, %Mongo.Error{} = reason, _s} ->
+        {:error, reason}
       {:error, reason} ->
         {:error, reason}
     end


### PR DESCRIPTION
`Mongo.Protocol.wire_version/1` can return a `{:disconnect, %Mongo.Error{}, s}`, but `Mongo.Protocol.connect/2` is missing a case clause to handle that. This manifested for me as a crash after shutting down a replica set member while testing replica set failover handling.