### PR TITLE
Support for mongodb+srv url

### DIFF
--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -111,10 +111,8 @@ defmodule Mongo.UrlParser do
   defp resolve_srv_url(%{"seeds" => url, "srv" => srv} = frags)
        when is_bitstring(url) and srv == "+srv" do
     # Fix for windows only
-    case :os.type() do
-      {:win32, _} ->
-        :inet_db.add_ns({4, 2, 2, 1})
-      _ ->
+    with {:win32, _} <- :os.type() do
+         :inet_db.add_ns({4, 2, 2, 1})
     end
 
     with url_char <- String.to_charlist(url),

--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -1,7 +1,7 @@
 defmodule Mongo.UrlParser do
   @moduledoc "Mongo connection URL parsing util"
 
-  @mongo_url_regex ~r/^mongodb:\/\/((?<username>[^:]+):(?<password>[^@]+)@)?(?<seeds>[^\/]+)(\/(?<database>[^?]+))?(\?(?<options>.*))?$/
+  @mongo_url_regex ~r/^mongodb(?<srv>\+srv)?:\/\/((?<username>[^:]+):(?<password>[^@]+)@)?(?<seeds>[^\/]+)(\/(?<database>[^?]+))?(\?(?<options>.*))?$/
 
   # https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options
   @mongo_options %{
@@ -23,7 +23,13 @@ defmodule Mongo.UrlParser do
     "wtimeoutMS" => :number,
     "journal" => ["true", "false"],
     "readConcernLevel" => ["local", "majority", "linearizable", "available"],
-    "readPreference" => ["primary", "primaryPreferred", "secondary", "secondaryPreferred", "nearest"],
+    "readPreference" => [
+      "primary",
+      "primaryPreferred",
+      "secondary",
+      "secondaryPreferred",
+      "nearest"
+    ],
     "maxStalenessSeconds" => :number,
     "readPreferenceTags" => :string,
     "authSource" => :string,
@@ -46,60 +52,110 @@ defmodule Mongo.UrlParser do
   }
 
   defp parse_option_value(_key, ""), do: nil
+
   defp parse_option_value(key, value) do
     case @mongo_options[key] do
-      :number -> String.to_integer(value)
-      :string -> value
+      :number ->
+        String.to_integer(value)
+
+      :string ->
+        value
+
       enum when is_list(enum) ->
         if Enum.member?(enum, value) do
           value
           |> Macro.underscore()
           |> String.to_atom()
         end
-      _other -> nil
+
+      _other ->
+        nil
     end
   end
 
-  defp add_option([key, value], opts), do:
-    add_option({key, value}, opts)
+  defp add_option([key, value], opts), do: add_option({key, value}, opts)
+
   defp add_option({key, value}, opts) do
     case parse_option_value(key, value) do
-      nil -> opts
+      nil ->
+        opts
+
       value ->
-        key = key
-        |> Macro.underscore()
-        |> String.to_atom()
+        key =
+          key
+          |> Macro.underscore()
+          |> String.to_atom()
+
         Keyword.put(opts, @driver_option_map[key] || key, value)
     end
   end
+
   defp add_option(_other, acc), do: acc
 
   defp parse_query_options(opts, %{"options" => options}) when is_binary(options) do
     options
     |> String.split("&")
-    |> Enum.map(fn(option) -> String.split(option, "=") end)
+    |> Enum.map(fn option -> String.split(option, "=") end)
     |> Enum.reduce(opts, &add_option/2)
   end
+
+  require Logger
   defp parse_query_options(opts, _frags), do: opts
 
-  defp parse_seeds(opts, %{"seeds" => seeds}) when is_binary(seeds) do
+  defp parse_seeds(opts, %{"seeds" => seeds}) do
     Keyword.put(opts, :seeds, String.split(seeds, ","))
   end
+
   defp parse_seeds(opts, _frags), do: opts
 
-  @spec parse_url(Keyword.t) :: Keyword.t
+  defp resolve_srv_url(%{"seeds" => url, "srv" => srv} = frags)
+       when is_bitstring(url) and srv == "+srv" do
+    # Fix for windows only
+    case :os.type() do
+      {:win32, _} ->
+        :inet_db.add_ns({4, 2, 2, 1})
+    end
+
+    with url_char <- String.to_charlist(url),
+         {:ok, {_, _, _, _, _, srv_record}} <-
+           :inet_res.getbyname('_mongodb._tcp.' ++ url_char, :srv),
+         {:ok, host} <- get_host_srv(srv_record),
+         {:ok, {_, _, _, _, _, txt_record}} <- :inet_res.getbyname(url_char, :txt),
+         txt <- "#{txt_record}&ssl=true" do
+      frags
+      |> Map.put("seeds", host)
+      |> Map.put("options", txt)
+    else
+      err -> err
+    end
+  end
+
+  defp resolve_srv_url(frags), do: frags
+
+  @spec get_host_srv([tuple]) :: {:ok, String.t()}
+  defp get_host_srv(srv) when is_list(srv) do
+    hosts =
+      srv
+      |> Enum.map(fn {_, _, port, host} -> "#{host}:#{port}" end)
+      |> Enum.join(",")
+
+    {:ok, hosts}
+  end
+
+  @spec parse_url(Keyword.t()) :: Keyword.t()
   def parse_url(opts) when is_list(opts) do
-    with  {url, opts} when is_binary(url) <- Keyword.pop(opts, :url),
-          frags when frags != nil         <- Regex.named_captures(@mongo_url_regex, url),
-          opts                            <- parse_seeds(opts, frags),
-          opts                            <- parse_query_options(opts, frags),
-          # Parse fixed parameters (database, username & password) & merge them with query options
-          opts                            <- Enum.reduce(frags, opts, &add_option/2)
-    do
+    with {url, opts} when is_binary(url) <- Keyword.pop(opts, :url),
+         frags when frags != nil <- Regex.named_captures(@mongo_url_regex, url),
+         frags <- resolve_srv_url(frags),
+         opts <- parse_seeds(opts, frags),
+         opts <- parse_query_options(opts, frags),
+         # Parse fixed parameters (database, username & password) & merge them with query options
+         opts <- Enum.reduce(frags, opts, &add_option/2) do
       opts
     else
       _other -> opts
     end
   end
+
   def parse_url(opts), do: opts
 end

--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -99,7 +99,6 @@ defmodule Mongo.UrlParser do
     |> Enum.reduce(opts, &add_option/2)
   end
 
-  require Logger
   defp parse_query_options(opts, _frags), do: opts
 
   defp parse_seeds(opts, %{"seeds" => seeds}) do
@@ -112,7 +111,7 @@ defmodule Mongo.UrlParser do
        when is_bitstring(url) and srv == "+srv" do
     # Fix for windows only
     with {:win32, _} <- :os.type() do
-         :inet_db.add_ns({4, 2, 2, 1})
+      :inet_db.add_ns({4, 2, 2, 1})
     end
 
     with url_char <- String.to_charlist(url),

--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -114,6 +114,7 @@ defmodule Mongo.UrlParser do
     case :os.type() do
       {:win32, _} ->
         :inet_db.add_ns({4, 2, 2, 1})
+      _ ->
     end
 
     with url_char <- String.to_charlist(url),

--- a/test/mongo/url_parser_test.exs
+++ b/test/mongo/url_parser_test.exs
@@ -6,23 +6,58 @@ defmodule Mongo.UrlParserTest do
 
   describe ".parse_url" do
     test "basic url" do
-      assert UrlParser.parse_url([url: "mongodb://localhost:27017"]) == [seeds: ["localhost:27017"]]
+      assert UrlParser.parse_url(url: "mongodb://localhost:27017") == [seeds: ["localhost:27017"]]
     end
+
     test "cluster url" do
-      url = "mongodb://user:password@seed1.domain.com:27017,seed2.domain.com:27017,seed3.domain.com:27017/db_name?ssl=true&replicaSet=set-name&authSource=admin&maxPoolSize=5"
-      assert UrlParser.parse_url([url: url]) == [
-        username: "user",
-        password: "password",
-        database: "db_name",
-        pool_size: 5,
-        auth_source: "admin",
-        set_name: "set-name",
-        ssl: true,
-        seeds: ["seed1.domain.com:27017", "seed2.domain.com:27017", "seed3.domain.com:27017"]
-      ]
+      url =
+        "mongodb://user:password@seed1.domain.com:27017,seed2.domain.com:27017,seed3.domain.com:27017/db_name?ssl=true&replicaSet=set-name&authSource=admin&maxPoolSize=5"
+
+      assert UrlParser.parse_url(url: url) == [
+               username: "user",
+               password: "password",
+               database: "db_name",
+               pool_size: 5,
+               auth_source: "admin",
+               set_name: "set-name",
+               ssl: true,
+               seeds: [
+                 "seed1.domain.com:27017",
+                 "seed2.domain.com:27017",
+                 "seed3.domain.com:27017"
+               ]
+             ]
     end
+
     test "merge options" do
-      assert UrlParser.parse_url([url: "mongodb://localhost:27017", name: :test, seeds: ["1234"]]) == [seeds: ["localhost:27017"], name: :test]
+      assert UrlParser.parse_url(url: "mongodb://localhost:27017", name: :test, seeds: ["1234"]) ==
+               [seeds: ["localhost:27017"], name: :test]
+    end
+
+    test "url srv" do
+      assert UrlParser.parse_url(url: "mongodb+srv://test.monopolio.org") ==
+               [
+                 ssl: true,
+                 auth_source: "authDB",
+                 set_name: "replProduction",
+                 seeds: [
+                   "mongo2.test.monopolio.org:27016","mongo3.test.monopolio.org:27018","mongo1.test.monopolio.org:27017"
+                 ]
+               ]
+    end
+
+    test "url srv with user" do
+      assert UrlParser.parse_url(url: "mongodb+srv://user:password@test.monopolio.org") ==
+               [
+                 username: "user",
+                 password: "password",
+                 ssl: true,
+                 auth_source: "authDB",
+                 set_name: "replProduction",
+                 seeds: [
+                   "mongo2.test.monopolio.org:27016","mongo3.test.monopolio.org:27018","mongo1.test.monopolio.org:27017"
+                 ]
+               ]
     end
   end
 end

--- a/test/mongo/url_parser_test.exs
+++ b/test/mongo/url_parser_test.exs
@@ -35,27 +35,27 @@ defmodule Mongo.UrlParserTest do
     end
 
     test "url srv" do
-      assert UrlParser.parse_url(url: "mongodb+srv://test.monopolio.org") ==
+      assert UrlParser.parse_url(url: "mongodb+srv://test5.test.build.10gen.cc") ==
                [
                  ssl: true,
-                 auth_source: "authDB",
-                 set_name: "replProduction",
+                 auth_source: "thisDB",
+                 set_name: "repl0",
                  seeds: [
-                   "mongo2.test.monopolio.org:27016","mongo3.test.monopolio.org:27018","mongo1.test.monopolio.org:27017"
+                   "localhost.test.build.10gen.cc:27017"
                  ]
                ]
     end
 
     test "url srv with user" do
-      assert UrlParser.parse_url(url: "mongodb+srv://user:password@test.monopolio.org") ==
+      assert UrlParser.parse_url(url: "mongodb+srv://user:password@test5.test.build.10gen.cc") ==
                [
                  username: "user",
                  password: "password",
                  ssl: true,
-                 auth_source: "authDB",
-                 set_name: "replProduction",
+                 auth_source: "thisDB",
+                 set_name: "repl0",
                  seeds: [
-                   "mongo2.test.monopolio.org:27016","mongo3.test.monopolio.org:27018","mongo1.test.monopolio.org:27017"
+                   "localhost.test.build.10gen.cc:27017"
                  ]
                ]
     end


### PR DESCRIPTION
This is the implementation for supporting mongodb+srv URL
I tested it with a MongoDB Atlas Account-
For the test cases, I simulated the SRV and TXT record with my own domain