### PR TITLE
Fix unused variable warning in Mongo.Topology

### DIFF
--- a/lib/mongo/topology.ex
+++ b/lib/mongo/topology.ex
@@ -121,7 +121,7 @@ defmodule Mongo.Topology do
     {:reply, :ok, new_state}
   end
 
-  def handle_call(:wait_for_connection, from, %{connection_pools: pools} = state) when map_size(pools) > 0 do
+  def handle_call(:wait_for_connection, _from, %{connection_pools: pools} = state) when map_size(pools) > 0 do
     servers = Enum.map(pools, fn {key, _value} -> key end)
     {:reply, {:connected, servers}, state}
   end


### PR DESCRIPTION
Fix the following warning:

```
warning: variable "from" is unused
  lib/mongo/topology.ex:124
```

Sorry if I missed a fix in another branch.