### PR TITLE
adding x509 auth support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ erl_crash.dump
 .tool-versions
 .elixir_ls
 plt_core_path/*.plt
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ To connect to a Mongo cluster that is using replica sets, it is recommended to u
 
 This will allow for scenarios where the first `"hostname1.net:27017"` is unreachable for any reason and will automatically try to connect to each of the following entries in the list to connect to the cluster.
 
+### Auth mechanisms
+
+For versions of Mongo 3.0 and greater, the auth mechanism defaults to SCRAM. If you'd like to use [MONGODB-X509](https://docs.mongodb.com/manual/tutorial/configure-x509-client-authentication/#authenticate-with-a-x-509-certificate) 
+authentication, you can specify that as a `start_link` option.
+
+```elixir
+{:ok, pid} = Mongo.start_link(database: "test", auth_mechanism: :x509)
+```
+
+### AWS, TLS and Erlang SSL ciphers
+
+Some MongoDB cloud providers (notably AWS) require a particular TLS cipher that isn't enabled by default in the Erlang SSL module. In order to connect to these services,
+you'll want to add this cipher to your `ssl_opts`: 
+
+```elixir
+{:ok, pid} = Mongo.start_link(database: "test", 
+      ssl_opts: [
+        ciphers: ['AES256-GCM-SHA384'],
+        cacertfile: "...",
+        certfile: "...")
+      ]
+)
+```
+
 ### Examples
 
 Using `$and`

--- a/examples/aws_x509.ex
+++ b/examples/aws_x509.ex
@@ -1,0 +1,19 @@
+defmodule AWSX509.Example do
+  def connect do
+    cert_dir = "/home/username/certs/"
+    {:ok, conn} = Mongo.start_link(
+      database: "database",
+      hostname: "mongodb.company.com",
+      username: "CN=username,OU=unit,O=company,L=Location,ST=State,C=US",
+      password: "foo",  # needs a dummy string. but would be nice if it could ignore this for X509
+      ssl: true,
+      auth_mechanism: :x509,
+      ssl_opts: [
+        ciphers: ['AES256-GCM-SHA384'],  # needed to connect to AWS
+        cacertfile: Path.join([cert_dir, "rootca.pem"]),
+        certfile: Path.join([cert_dir, "mycert.pem"])
+      ]
+    )
+    conn
+  end
+end

--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -112,6 +112,8 @@ defmodule Mongo do
     * `:after_connect` - A function to run on connect use `run/3`. Either a
       1-arity fun, `{module, function, args}` with `DBConnection.t`, prepended
       to `args` or `nil` (default: `nil`)
+    * `:auth_mechanism` - options for the mongo authentication mechanism,
+      currently only supports `:x509` atom as a value
     * `:ssl` - Set to `true` if ssl should be used (default: `false`)
     * `:ssl_opts` - A list of ssl options, see the ssl docs
 

--- a/lib/mongo/auth.ex
+++ b/lib/mongo/auth.ex
@@ -39,7 +39,7 @@ defmodule Mongo.Auth do
     if username && password, do: auth ++ [{username, password}], else: auth
   end
 
-  defp mechanism(%{wire_version: version, auth_mechanism: "MONGODB-X509"}) when version >= 3,
+  defp mechanism(%{wire_version: version, auth_mechanism: :x509}) when version >= 3,
     do: Mongo.Auth.X509
   defp mechanism(%{wire_version: version}) when version >= 3,
     do: Mongo.Auth.SCRAM

--- a/lib/mongo/auth.ex
+++ b/lib/mongo/auth.ex
@@ -39,6 +39,8 @@ defmodule Mongo.Auth do
     if username && password, do: auth ++ [{username, password}], else: auth
   end
 
+  defp mechanism(%{wire_version: version, auth_mechanism: "MONGODB-X509"}) when version >= 3,
+    do: Mongo.Auth.X509
   defp mechanism(%{wire_version: version}) when version >= 3,
     do: Mongo.Auth.SCRAM
   defp mechanism(_),

--- a/lib/mongo/auth/x509.ex
+++ b/lib/mongo/auth/x509.ex
@@ -1,0 +1,15 @@
+defmodule Mongo.Auth.X509 do
+  @moduledoc false
+  import Mongo.Protocol.Utils
+
+  def auth({username, _password}, s) do
+    cmd = [authenticate: 1, user: username, mechanism: "MONGODB-X509"]
+    with {:ok, _message} <- command(-2, cmd, s) do
+      :ok
+    else
+      _error ->
+        {:error, "X509 auth failed"}
+    end
+  end
+
+end

--- a/lib/mongo/protocol.ex
+++ b/lib/mongo/protocol.ex
@@ -90,7 +90,6 @@ defmodule Mongo.Protocol do
   defp ssl(%{socket: {:gen_tcp, sock}} = s, opts) do
     host      = (opts[:hostname] || "localhost") |> to_charlist
     ssl_opts = Keyword.put_new(opts[:ssl_opts] || [], :server_name_indication, host)
-    ssl_opts = Keyword.put_new(ssl_opts, :ciphers, ['AES256-GCM-SHA384'])
     case :ssl.connect(sock, ssl_opts, s.connect_timeout_ms) do
       {:ok, ssl_sock} ->
         {:ok, %{s | socket: {:ssl, ssl_sock}}}

--- a/lib/mongo/protocol.ex
+++ b/lib/mongo/protocol.ex
@@ -89,6 +89,7 @@ defmodule Mongo.Protocol do
   defp ssl(%{socket: {:gen_tcp, sock}} = s, opts) do
     host      = (opts[:hostname] || "localhost") |> to_charlist
     ssl_opts = Keyword.put_new(opts[:ssl_opts] || [], :server_name_indication, host)
+    ssl_opts = Keyword.put_new(ssl_opts, :ciphers, ['AES256-GCM-SHA384'])
     case :ssl.connect(sock, ssl_opts, s.connect_timeout_ms) do
       {:ok, ssl_sock} ->
         {:ok, %{s | socket: {:ssl, ssl_sock}}}

--- a/lib/mongo/protocol.ex
+++ b/lib/mongo/protocol.ex
@@ -33,6 +33,7 @@ defmodule Mongo.Protocol do
       database: Keyword.fetch!(opts, :database),
       write_concern: Map.new(write_concern),
       wire_version: nil,
+      auth_mechanism: opts[:auth_mechanism] || nil,
       connection_type: Keyword.fetch!(opts, :connection_type),
       topology_pid: Keyword.fetch!(opts, :topology_pid),
       ssl: opts[:ssl] || false

--- a/lib/mongo/protocol/utils.ex
+++ b/lib/mongo/protocol/utils.ex
@@ -15,8 +15,14 @@ defmodule Mongo.Protocol.Utils do
   end
 
   def command(id, command, s) do
-    op = op_query(coll: namespace("$cmd", s, nil), query: BSON.Encoder.document(command),
+    op = case command do
+      [authenticate: 1, user: _username, mechanism: "MONGODB-X509"] ->
+        op_query(coll: namespace("$cmd", nil, "$external"), query: BSON.Encoder.document(command),
                   select: "", num_skip: 0, num_return: 1, flags: [])
+      _command ->
+        op_query(coll: namespace("$cmd", s, nil), query: BSON.Encoder.document(command),
+                  select: "", num_skip: 0, num_return: 1, flags: [])
+    end
     case message(id, op, s) do
       {:ok, op_reply(docs: docs)} ->
         case BSON.Decoder.documents(docs) do


### PR DESCRIPTION
Some notes:
No tests, sorry. It'd probably take a fair bit for me to learn how to do that, but I can if needed.
I'm not entirely sure if adding the cipher to the `ssl_opts` is necessary for X509 by itself, but it's definitely necessary to connect to AWS, where I was testing this.
I didn't feel up to revising `Mongo.Auth.setup` to not require a password if connecting with X509, so for now, you need to provide a dummy string password in the `start_link` params, even though X509 doesn't require a password. The connection looks like this:
```
    {:ok, conn} = Mongo.start_link(
      database: "mydatabase",
      hostname: "mymongo.host.com",
      username: "LDAP valid username",
      password: "foo",  # still required unless Mongo.Auth.setup can be made smarter
      ssl: true,
      auth_mechanism: "MONGODB-X509",
      ssl_opts: [
        cacertfile: "/path/to/ca-cert.pem",
        certfile: "/path/to/cert.pem"
      ]
    )
```