### PR TITLE
fix 1.7 deprecations

### DIFF
--- a/lib/mongo/topology.ex
+++ b/lib/mongo/topology.ex
@@ -69,7 +69,7 @@ defmodule Mongo.Topology do
     cond do
       type == :single and length(seeds) > 1 ->
         {:stop, :single_topology_multiple_hosts}
-      set_name != nil and not type in [:unknown, :replica_set_no_primary, :single] ->
+      set_name != nil and not(type in [:unknown, :replica_set_no_primary, :single]) ->
         {:stop, :set_name_bad_topology}
       true ->
         servers = servers_from_seeds(seeds)

--- a/lib/mongo/topology_description.ex
+++ b/lib/mongo/topology_description.ex
@@ -340,7 +340,7 @@ defmodule Mongo.TopologyDescription do
   # see https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#actions
 
   defp not_in_servers?(topology, server_description) do
-    not server_description.address in Map.keys(topology.servers)
+    not(server_description.address in Map.keys(topology.servers))
   end
 
   def invalid_set_name?(topology, server_description) do
@@ -394,7 +394,7 @@ defmodule Mongo.TopologyDescription do
     all_hosts =
       server_description.hosts ++ server_description.passives ++ server_description.arbiters
     topology = Enum.reduce(all_hosts, topology, fn (host, topology) ->
-      if not host in Map.keys(topology.servers) do
+      if not(host in Map.keys(topology.servers)) do
         # this is kinda like an "upsert"
         put_in(topology.servers[host], ServerDescription.defaults(%{address: host}))
       else


### PR DESCRIPTION
```
==> mongodb
Compiling 30 files (.ex)
warning: "not expr1 in expr2" is deprecated. Instead use "expr1 not in expr2" if you require Elixir v1.5+, or "not(expr1 in expr2)" if you have to support earlier Elixir versions
  lib/mongo/topology.ex:72

warning: "not expr1 in expr2" is deprecated. Instead use "expr1 not in expr2" if you require Elixir v1.5+, or "not(expr1 in expr2)" if you have to support earlier Elixir versions
  lib/mongo/topology_description.ex:343

warning: "not expr1 in expr2" is deprecated. Instead use "expr1 not in expr2" if you require Elixir v1.5+, or "not(expr1 in expr2)" if you have to support earlier Elixir versions
  lib/mongo/topology_description.ex:397


== Compilation error in file lib/mongo/protocol.ex ==
** (CompileError) lib/mongo/protocol.ex:4: module DBConnection is not loaded and could not be found
    (elixir) expanding macro: Kernel.use/1
    lib/mongo/protocol.ex:4: Mongo.Protocol (module)
could not compile dependency :mongodb, "mix compile" failed. You can recompile this dependency with "mix deps.compile mongodb", update it with "mix deps.update mongodb" or clean it with "mix deps.clean mongodb"
```