### PR TITLE
Allow passing read_preference without all keys

### DIFF
--- a/lib/mongo/read_preference.ex
+++ b/lib/mongo/read_preference.ex
@@ -9,11 +9,15 @@ defmodule Mongo.ReadPreference do
     max_staleness_ms: non_neg_integer
   }
 
-  def defaults(map \\ %{}) do
-    Map.merge(%{
-      mode: :primary,
-      tag_sets: [%{}],
-      max_staleness_ms: 0
-    }, map)
+  @default %{
+    mode: :primary,
+    tag_sets: [%{}],
+    max_staleness_ms: 0
+  }
+
+  def defaults(map \\ nil)
+  def defaults(map) when is_map(map) do
+    Map.merge(@default, map)
   end
+  def defaults(_), do: @default
 end

--- a/lib/mongo/topology_description.ex
+++ b/lib/mongo/topology_description.ex
@@ -51,8 +51,8 @@ defmodule Mongo.TopologyDescription do
 
   # steps 3-4
   def select_servers(topology, type, opts \\ []) do
-    read_preference = Keyword.get(opts, :read_preference,
-                                  ReadPreference.defaults)
+    read_preference = Keyword.get(opts, :read_preference)
+                      |> ReadPreference.defaults()
     if topology[:compatible] == false do
       {:error, :invalid_wire_version}
     else

--- a/test/mongo/topology_description_test.exs
+++ b/test/mongo/topology_description_test.exs
@@ -58,5 +58,16 @@ defmodule Mongo.TopologyDescriptionTest do
     ]
     assert {:ok, all_hosts, true, false} ==
            TopologyDescription.select_servers(repl_set_no_master(), :read, opts)
+
+  end
+
+  test "Simplified server selection" do
+    single_server = ["localhost:27017"]
+
+    opts = [
+      read_preference: %{mode: :secondary}
+    ]
+    assert {:ok, single_server, true, false} ==
+           TopologyDescription.select_servers(single(), :read, opts)
   end
 end


### PR DESCRIPTION
Currently specify the ```read_preference``` requires to pass all keys as done in 
https://github.com/ankhers/mongodb/blob/65bd68adbc2753c38d927ad0ba804fe8e66d50d7/test/mongo/topology_description_test.exs#L10

This is confusing and not handy. I made this commit to support it.
