### PR TITLE
Respect secondary_preferred read preference by falling back to primary

### DIFF
--- a/test/mongo/topology_description_test.exs
+++ b/test/mongo/topology_description_test.exs
@@ -39,6 +39,19 @@ defmodule Mongo.TopologyDescriptionTest do
            TopologyDescription.select_servers(repl_set_with_master(), :read, opts)
 
     opts = [
+      read_preference: ReadPreference.defaults(%{mode: :primary_preferred})
+    ]
+    assert {:ok, [master], true, false} ==
+      TopologyDescription.select_servers(repl_set_with_master(), :read, opts)
+
+    opts = [
+      read_preference: ReadPreference.defaults(%{mode: :primary_preferred})
+    ]
+    assert {:ok, List.delete(all_hosts, master), true, false} ==
+      TopologyDescription.select_servers(repl_set_no_master(), :read, opts)
+
+
+    opts = [
       read_preference: ReadPreference.defaults(%{mode: :nearest})
     ]
     assert {:ok, all_hosts, true, false} ==
@@ -50,8 +63,17 @@ defmodule Mongo.TopologyDescriptionTest do
     assert {:ok, List.delete(all_hosts, master), true, false} ==
            TopologyDescription.select_servers(repl_set_no_master(), :read, opts)
 
-    assert {:ok, [], false, false} ==
-           TopologyDescription.select_servers(repl_set_no_master(), :write)
+    opts = [
+      read_preference: ReadPreference.defaults(%{mode: :secondary_preferred})
+    ]
+    assert {:ok, List.delete(all_hosts, master), true, false} ==
+      TopologyDescription.select_servers(repl_set_with_master(), :read, opts)
+
+    assert {:ok, [master], true, false} ==
+      TopologyDescription.select_servers(repl_set_only_master(), :read, opts)
+
+    assert {:ok, List.delete(all_hosts, master), true, false} ==
+           TopologyDescription.select_servers(repl_set_no_master(), :read, opts)
 
     opts = [
       read_preference: ReadPreference.defaults(%{mode: :nearest})

--- a/test/support/topology_test_data.ex
+++ b/test/support/topology_test_data.ex
@@ -191,4 +191,35 @@ defmodule Mongo.TopologyTestData do
       }
     }
   }
+  def repl_set_only_master, do: %{
+    compatibility_error: nil,
+    compatible: true,
+    local_threshold_ms: 15,
+    set_name: "replset1",
+    type: :replica_set_with_primary,
+    max_election_id: nil,
+    max_set_version: 3,
+    servers: %{
+      "localhost:27018" => %{
+        address: "localhost:27018",
+        arbiters: [],
+        election_id: nil,
+        error: nil,
+        last_update_time: nil,
+        last_write_date: nil,
+        max_wire_version: 0,
+        me: nil,
+        min_wire_version: 0,
+        op_time: nil,
+        passives: [],
+        primary: nil,
+        round_trip_time: 15,
+        set_name: nil,
+        set_version: nil,
+        tag_set: %{},
+        type: :rs_primary,
+        hosts: ["localhost:27018"]
+      }
+    }
+  }
 end


### PR DESCRIPTION
As this read preference is following the exact same code path as the secondary
read preference, this has the side-effect of not being able to make read
operations when only the primary is available.

According to the [MongoDB documentation](https://docs.mongodb.com/manual/core/read-preference-mechanics/#replica-set-read-preference-behavior) for the `secondary_preferred`:
>  1. Following the server selection process for the read preference secondary, if a list of eligible secondary members is non-empty, driver chooses an eligible secondary member.
> 2. Otherwise, if the list is empty, driver selects the primary.

This change ensures this fallback and simplifies the primary_preferred
implementation to mimic the behaviour, only the other way around.