### PR TITLE
Review usage of `slave_ok` flag according to the driver spec

### DIFF
--- a/lib/mongo/topology_description.ex
+++ b/lib/mongo/topology_description.ex
@@ -92,7 +92,7 @@ defmodule Mongo.TopologyDescription do
 
   ## Private Functions
 
-  defp select_replica_set_server(topology, :primary, read_preference) do
+  defp select_replica_set_server(topology, :primary, _read_preference) do
     Enum.filter(topology.servers, fn {_, server} ->
       server.type == :rs_primary
     end)


### PR DESCRIPTION
This PR directly addresses the inconsistencies uncovered in #250, where the usage of a read preference allowing reads from secondaries would not play well with the value of `slave_ok`, which in the driver defaults to `false` (not setting the flag).

It follows directions in https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#use-of-slaveok and tackles the following issues:
1. Inconsistencies regarding `slave_ok`'s implicit behavior
2. `findAndModify` operations relying on a `read` server selection (instead of `write`)

Moreover, for cursor-based queries the `slave_ok` option is already implicitly set (and reused for further `getmore` invocations) but commands such as `count` would fail with a non-primary read preference (because `slave_ok` would be set to false). 

The way to workaround this limitation would be to use the deprecated and undocumented behaviour of passing `slave_ok: true` as a query option, so that it would override the default and allow some commands to go through on secondaries. A side-effect of this would be all the `findAndModify` operations (`find_one_and_update`, `find_one_and_replace` and `find_one_and_delete`) to also go through secondaries, which the default `slave_ok` prevented, but should never be possible (as these are equivalent to write operations).

The driver specification goes even further and mentions this combination of options used for the workaround as an error:
> If a driver API allows users to potentially set both the legacy slaveOK configuration option and a default read preference configuration option, passing a value for both MUST be an error. (See Use of slaveOk for the two uses of slaveOK.)

This PR removes the need for the workaround by having `slave_ok` consistent with the server selection algorithm but doesn't prohibit the combination of options as the backwards compatibility for this option is not totally clear.