### PR TITLE
Mongo read preference defaults fixes for max_staleness_ms > 0

### DIFF
--- a/lib/mongo/topology.ex
+++ b/lib/mongo/topology.ex
@@ -79,7 +79,8 @@ defmodule Mongo.Topology do
               type: type,
               set_name: set_name,
               servers: servers,
-              local_threshold_ms: local_threshold_ms
+              local_threshold_ms: local_threshold_ms,
+              heartbeat_frequency_ms: @heartbeat_frequency_ms
             }),
             seeds: seeds,
             opts: opts,

--- a/lib/mongo/topology_description.ex
+++ b/lib/mongo/topology_description.ex
@@ -146,7 +146,7 @@ defmodule Mongo.TopologyDescription do
             end)
           server
         :replica_set_with_primary ->
-          servers
+          topology.servers
           |> Enum.filter(fn {_, server} ->
             server.type == :rs_primary
           end)
@@ -160,13 +160,13 @@ defmodule Mongo.TopologyDescription do
             case topology.type do
               :replica_set_no_primary ->
                 staleness =
-                  extra.last_write_date + (server.last_update_time - extra.last_update_time) -
-                  server.last_write_date + topology.heartbeat_frequency_ms
+                  DateTime.diff(extra.last_write_date, server.last_write_date, :milliseconds) + DateTime.diff(server.last_update_time, extra.last_update_time, :milliseconds) + topology.heartbeat_frequency_ms
                 staleness <= max_staleness_ms
 
               :replica_set_with_primary ->
+                {_, extra_props} = extra
                 staleness =
-                  extra.last_write_date - server.last_write_date + topology.heartbeat_frequency_ms
+                  DateTime.diff(extra_props.last_write_date, server.last_write_date, :milliseconds) + topology.heartbeat_frequency_ms
                 staleness <= max_staleness_ms
             end
           _ ->


### PR DESCRIPTION
- crash fixes for max_staleness_ms when it was greater than 0.
- topology structure changes for giving heartbeat_frequency_ms in structure.

read_preference:  Mongo.ReadPreference.defaults(%{mode: :secondary_preferred, max_staleness_ms: 10_000})
- now we can use max staleness param too.

please let me know if any other suggestions for this. As this is my first contribution.