### PR TITLE
Add missing host parameter to exception call

### DIFF
--- a/lib/mongo/protocol/utils.ex
+++ b/lib/mongo/protocol/utils.ex
@@ -121,12 +121,12 @@ defmodule Mongo.Protocol.Utils do
   end
 
   defp send_error(reason, s) do
-    error = Mongo.Error.exception(tag: :tcp, action: "send", reason: reason)
+    error = Mongo.Error.exception(tag: :tcp, action: "send", reason: reason, host: s.host)
     {:disconnect, error, s}
   end
 
   defp recv_error(reason, s) do
-    error = Mongo.Error.exception(tag: :tcp, action: "recv", reason: reason)
+    error = Mongo.Error.exception(tag: :tcp, action: "recv", reason: reason, host: s.host)
     {:disconnect, error, s}
   end
 


### PR DESCRIPTION
send_error and recv_error create a Mongo.Error without
host and this fails with the following error message:

no function clause matching in Mongo.Error.exception/1
Mongo.Error.exception([tag: :tcp, action: \"recv\", reason: :timeout])