### PR TITLE
stop old connection pool

### DIFF
--- a/lib/mongo/topology.ex
+++ b/lib/mongo/topology.ex
@@ -171,7 +171,10 @@ defmodule Mongo.Topology do
             |> connect_opts_from_address(host)
 
           {:ok, pool} = DBConnection.start_link(Mongo.Protocol, conn_opts)
-          connection_pools = Map.put(state.connection_pools, host, pool)
+          connection_pools = Map.update(state.connection_pools, host, pool, fn old_pool ->
+            GenServer.stop(old_pool)
+            pool
+          end)
           Enum.each(state.waiting_pids, fn from ->
             GenServer.reply(from, {:new_connection, host})
           end)

--- a/test/mongo/topology_test.exs
+++ b/test/mongo/topology_test.exs
@@ -1,8 +1,9 @@
 defmodule Mongo.TopologyTest do
-  use ExUnit.Case # DO NOT MAKE ASYNCHRONOUS
+  # DO NOT MAKE ASYNCHRONOUS
+  use ExUnit.Case
 
   setup_all do
-    assert {:ok, pid} = Mongo.TestConnection.connect
+    assert {:ok, pid} = Mongo.TestConnection.connect()
     %{pid: pid}
   end
 
@@ -13,13 +14,41 @@ defmodule Mongo.TopologyTest do
                Mongo.insert_one(mongo_pid, "test", %{topology_test: 1}, w: 3)
 
       rp = Mongo.ReadPreference.defaults(%{mode: mode})
+
       assert [%{"_id" => ^new_id, "topology_test" => 1}] =
                mongo_pid
                |> Mongo.find("test", %{_id: new_id}, read_preference: rp)
-               |> Enum.to_list
+               |> Enum.to_list()
 
       assert {:ok, %Mongo.DeleteResult{deleted_count: 1}} =
                Mongo.delete_one(mongo_pid, "test", %{_id: new_id})
+    end
+  end
+
+  test "remove old connection_pool", %{pid: mongo_pid} do
+    :erlang.trace(mongo_pid, true, [:receive])
+    %{monitors: %{"127.0.0.1:27001" => monitor_pid}} = state = :sys.get_state(mongo_pid)
+
+    case state do
+      %{connection_pools: %{"127.0.0.1:27001" => connection_pid}} ->
+        GenServer.cast(mongo_pid, {:connected, monitor_pid})
+
+        %{connection_pools: %{"127.0.0.1:27001" => new_connection_pid}} =
+          :sys.get_state(mongo_pid)
+
+        assert connection_pid != new_connection_pid
+
+      _ ->
+        assert_receive {:trace, ^mongo_pid, :receive, {:"$gen_cast", {:connected, ^monitor_pid}}}
+        %{connection_pools: %{"127.0.0.1:27001" => connection_pid}} = :sys.get_state(mongo_pid)
+        ref = Process.monitor(connection_pid)
+        GenServer.cast(mongo_pid, {:connected, monitor_pid})
+        assert_receive {:DOWN, ^ref, :process, ^connection_pid, :normal}
+
+        %{connection_pools: %{"127.0.0.1:27001" => new_connection_pid}} =
+          :sys.get_state(mongo_pid)
+
+        assert connection_pid != new_connection_pid
     end
   end
 end


### PR DESCRIPTION
if application and db on different hosts and mongo restarted, app creates more than one connection pools