### PR TITLE
Add support for the :binary_old subtype for BSON.Binary

### DIFF
--- a/lib/bson/decoder.ex
+++ b/lib/bson/decoder.ex
@@ -51,6 +51,11 @@ defmodule BSON.Decoder do
     list(binary)
   end
 
+  defp type(@type_binary, <<_size::int32, subtype, length::int32, binary::binary(length), rest::binary>>) when subtype == 0x02 do
+    subtype = subtype(subtype)
+    {%BSON.Binary{binary: binary, subtype: subtype}, rest}
+  end
+
   defp type(@type_binary, <<size::int32, subtype, binary::binary(size), rest::binary>>) do
     subtype = subtype(subtype)
     {%BSON.Binary{binary: binary, subtype: subtype}, rest}

--- a/lib/bson/encoder.ex
+++ b/lib/bson/encoder.ex
@@ -17,6 +17,12 @@ defmodule BSON.Encoder do
   def encode(:BSON_max),
     do: ""
 
+  def encode(%BSON.Binary{binary: binary, subtype: :binary_old}) do
+    subtype = subtype(:binary_old)
+    size = IO.iodata_length(binary)
+    [<<size + 4::int32>>, subtype, <<size::int32>>, binary]
+  end
+
   def encode(%BSON.Binary{binary: binary, subtype: subtype}) do
     subtype = subtype(subtype)
     [<<IO.iodata_length(binary)::int32>>, subtype | binary]

--- a/test/bson_test.exs
+++ b/test/bson_test.exs
@@ -72,7 +72,7 @@ defmodule BSONTest do
   @map20 %{"p" => :BSON_max}
   @bin20 <<8, 0, 0, 0, 127, 112, 0, 0>>
 
-  @map21 %{"q" => %BSON.Binary{binary: <<1,2,3>>, subtype: :binary_old}}
+  @map21 %{"q" => %BSON.Binary{binary: <<1, 2, 3>>, subtype: :binary_old}}
   @bin21 <<20, 0, 0, 0, 5, 113, 0, 7, 0, 0, 0, 2, 3, 0, 0, 0, 1, 2, 3, 0>>
 
   test "encode" do

--- a/test/bson_test.exs
+++ b/test/bson_test.exs
@@ -72,6 +72,9 @@ defmodule BSONTest do
   @map20 %{"p" => :BSON_max}
   @bin20 <<8, 0, 0, 0, 127, 112, 0, 0>>
 
+  @map21 %{"q" => %BSON.Binary{binary: <<1,2,3>>, subtype: :binary_old}}
+  @bin21 <<20, 0, 0, 0, 5, 113, 0, 7, 0, 0, 0, 2, 3, 0, 0, 0, 1, 2, 3, 0>>
+
   test "encode" do
     assert encode(@map1)  == @bin1
     assert encode(@map2)  == @bin2
@@ -93,6 +96,7 @@ defmodule BSONTest do
     assert encode(@map18) == @bin18
     assert encode(@map19) == @bin19
     assert encode(@map20) == @bin20
+    assert encode(@map21) == @bin21
   end
 
   test "decode" do
@@ -116,6 +120,7 @@ defmodule BSONTest do
     assert decode(@bin18) == @map18
     assert decode(@bin19) == @map19
     assert decode(@bin20) == @map20
+    assert decode(@bin21) == @map21
   end
 
   test "keywords" do


### PR DESCRIPTION
The problem is discussed in Issue #290.

This PR is a work in progress.  The proposed code change is working on my production dataset. 
Remaining is devising a test strategy.  I don't think it's going to be possible to insert the old binary format into a test DB so we may need to do something else.