### PR TITLE
Update documentation on BSON document decoding (fix #288)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
     min key             :BSON_min
     max key             :BSON_max
 
-1) Since BSON documents are ordered Elixir maps cannot be used to fully represent them. This driver chose to accept both maps and lists of key-value pairs when encoding but will only decode documents to lists. This has the side-effect that it's impossible to discern empty arrays from empty documents. Additionally the driver will accept both atoms and strings for document keys but will only decode to strings.
+1) Since BSON documents are ordered Elixir maps cannot be used to fully represent them. This driver chose to accept both maps and lists of key-value pairs when encoding but will only decode documents to maps. This has the side-effect that the information about order of keys in a BSON document is lost when it's decoded. Additionally the driver will accept both atoms and strings for document keys but will only decode to strings.
 
 2) BSON symbols can only be decoded.
 


### PR DESCRIPTION
What the title and issue #288 say.

I'm pretty sure it always decodes documents to maps, based on tests and on [this line](https://github.com/ankhers/mongodb/blob/master/lib/bson/decoder.ex#L150), anyway it's probably a good idea if someone can check and confirm.

I added the note about loss of key order since while it's likely when iterating the map you'll see the keys in the same order they were stored in MongoDB due to [this reason](https://stackoverflow.com/a/40408469) (current under-the-hood implementation of "small" - less than ~32 keys - maps in Elixir being actually an ordered data structure), [maps are unordered by design](https://hexdocs.pm/elixir/Map.html) thus 1) you get them in a "random" order right now if you have larger documents, and 2) there is, in my understanding, no guarantee of this to remain stable over the course of Elixir releases.