### PR TITLE
Add LDAP Auth for MongoDB Enterprise

### DIFF
--- a/lib/mongo/auth.ex
+++ b/lib/mongo/auth.ex
@@ -39,6 +39,8 @@ defmodule Mongo.Auth do
     if username && password, do: auth ++ [{username, password}], else: auth
   end
 
+  defp mechanism(%{auth_mechanism: :plain}),
+    do: Mongo.Auth.Plain
   defp mechanism(%{wire_version: version, auth_mechanism: :x509}) when version >= 3,
     do: Mongo.Auth.X509
   defp mechanism(%{wire_version: version}) when version >= 3,

--- a/lib/mongo/auth/ldap.ex
+++ b/lib/mongo/auth/ldap.ex
@@ -1,0 +1,15 @@
+defmodule Mongo.Auth.Plain do
+  @moduledoc false
+
+  import Mongo.Protocol.Utils
+
+  def auth({username, password}, s) do
+    encoded_auth = Base.encode64("\x00#{username}\x00#{password}")
+    result = command(-1, [saslStart: 1, mechanism: "PLAIN", payload: encoded_auth, autoAuthorize: 1], s)
+
+    case result do
+      {:ok, _res} -> :ok
+      error -> error
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Mongodb.Mixfile do
   use Mix.Project
 
-  @version "0.5.1"
+  @version "0.4.8"
 
   def project do
     [app: :mongodb,
@@ -37,7 +37,7 @@ defmodule Mongodb.Mixfile do
   defp deps do
     [
       {:connection,    "~> 1.0"},
-      {:db_connection, "~> 2.0"},
+      {:db_connection, "~> 1.1"},
       {:decimal,       "~> 1.5"},
       # {:poolboy,       ">= 0.0.0", only: :test},
       {:jason,         "~> 1.0.0", only: :test},


### PR DESCRIPTION
I know this isn't a burning need in the community, but it would be super helpful if we could push this into a `0.4.x` release. 

This change would extend current functionality by allowing for LDAP Authorization by passing the `auth_mechanism: :plain` as an option to the `start_link` function.