### PR TITLE
Fix doc for default timeout

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -9,7 +9,7 @@ defmodule Mongo do
 
     * `:timeout` - The maximum time that the caller is allowed the to hold the
       connection’s state (ignored when using a run/transaction connection,
-      default: `15_000`)
+      default: `5_000`)
     * `:pool` - The pooling behaviour module to use, this option is required
       unless the default `DBConnection.Connection` pool is used
     * `:pool_timeout` - The maximum time to wait for a reply when making a


### PR DESCRIPTION
I was getting this error for some slow queries:
```
[error] Mongo.Protocol (#PID<0.570.0>) disconnected: ** (DBConnection.ConnectionError)
client #PID<0.635.0> timed out because it checked out the connection for longer than
5000ms
```
while documentation for `:timeout` said the default was `15_000`.

So I looked at the `mongo.ex` source file and found no instances of `15000` being used as default timeout, and noticed instead that when there is no `:timeout` option value, `5000` is used (lines [1055](https://github.com/ankhers/mongodb/blob/v0.5.1/lib/mongo.ex#L1055) and [57](https://github.com/ankhers/mongodb/blob/v0.5.1/lib/mongo.ex#L57) in v0.5.1).