### PR TITLE
Implement Decimal128.decode

### DIFF
--- a/lib/bson/decimal128.ex
+++ b/lib/bson/decimal128.ex
@@ -65,11 +65,11 @@ defmodule BSON.Decimal128 do
     set_exponent(high, exp, two_highest_bits_set)
   end
 
-  defp set_exponent(high, exp, _two_highest_bits_set = false) do
+  defp set_exponent(high, exp, false = _two_highest_bits_set) do
     biased_exponent = exp + @exponent_bias
     bor(high, biased_exponent <<< 49)
   end
-  defp set_exponent(high, exp, _two_highest_bits_set = true) do
+  defp set_exponent(high, exp, true = _two_highest_bits_set) do
     biased_exponent = exp + @exponent_bias
     high = high &&& 0x7fffffffffff
     high = bor(high, 3 <<< 61)

--- a/lib/bson/encoder.ex
+++ b/lib/bson/encoder.ex
@@ -36,6 +36,10 @@ defmodule BSON.Encoder do
     <<unix_ms::int64>>
   end
 
+  def encode(%Decimal{} = decimal) do
+    BSON.Decimal128.encode(decimal)
+  end
+
   def encode(%BSON.Regex{pattern: pattern, options: options}),
     do: [cstring(pattern) | cstring(options)]
 
@@ -138,6 +142,7 @@ defmodule BSON.Encoder do
   defp type(%BSON.Binary{}), do: @type_binary
   defp type(%BSON.ObjectId{}), do: @type_objectid
   defp type(%DateTime{}), do: @type_datetime
+  defp type(%Decimal{}), do: @type_decimal128
   defp type(%BSON.Regex{}), do: @type_regex
   defp type(%BSON.JavaScript{scope: nil}), do: @type_js
   defp type(%BSON.JavaScript{}), do: @type_js_scope

--- a/test/bson/decimal128_test.exs
+++ b/test/bson/decimal128_test.exs
@@ -53,4 +53,39 @@ defmodule BSON.Decimal128Test do
   defp assert_decimal(binaries, expected_decimal) do
     assert BSON.Decimal128.decode(binaries) == expected_decimal
   end
+
+  @tag :mongo_3_4
+  test "BSON.Decimal128.encode/1" do
+    assert_binary_decimal(%Decimal{coef: :qNaN}, @nan_binaries)
+    assert_binary_decimal(%Decimal{coef: :inf}, @inf_binaries)
+    assert_binary_decimal(%Decimal{sign: -1, coef: :inf}, @neg_inf_binaries)
+    assert_binary_decimal(%Decimal{coef: 0}, @binaries_0)
+    assert_binary_decimal(%Decimal{coef: 0, exp: -611}, @binaries_0_neg_expo)
+    assert_binary_decimal(%Decimal{sign: -1, coef: 0, exp: -1}, @binaries_neg_0_0)
+    assert_binary_decimal(%Decimal{coef: 1, exp: 3}, @binaries_1_e_3)
+    assert_binary_decimal(%Decimal{coef: 1234, exp: -6}, @binaries_0_001234)
+    assert_binary_decimal(%Decimal{coef: 123_400_000, exp: -11}, @binaries_0_00123400000)
+
+    assert_binary_decimal(%Decimal{
+      coef: 1_234_567_890_123_456_789_012_345_678_901_234,
+      exp: -34
+    }, @binaries_0_1234567890123456789012345678901234)
+
+    assert_binary_decimal(%Decimal{
+      coef: 1_234_567_890_123_456_789_012_345_678_901_234,
+      exp: 0
+    }, @binaries_regular_largest)
+
+    assert_binary_decimal(%Decimal{
+      coef: 9_999_999_999_999_999_999_999_999_999_999_999,
+      exp: -6176
+    }, @binaries_scientific_tiniest)
+
+    assert_binary_decimal(%Decimal{coef: 1, exp: -6176}, @binaries_scientific_tiny)
+    assert_binary_decimal(%Decimal{sign: -1, coef: 1, exp: -6176}, @binaries_neg_tiny)
+  end
+
+  defp assert_binary_decimal(decimal, expected_binary) do
+    assert BSON.Decimal128.encode(decimal) == expected_binary
+  end
 end


### PR DESCRIPTION
Converting Decimal into binary so that it can actually be stored.
The PR https://github.com/ankhers/mongodb/pull/221 only added
support for querying but not inserting decimals.