### PR TITLE
Add Topology.has_readable_server? real implementation

### DIFF
--- a/lib/mongo/topology_description.ex
+++ b/lib/mongo/topology_description.ex
@@ -41,8 +41,12 @@ defmodule Mongo.TopologyDescription do
     )
   end
 
-  def has_readable_server?(_topology, _read_preference) do
-    true
+  @doc """
+  This method allows you to check if current topology contains the readable server.
+  """
+  def has_readable_server?(topology, opts \\ []) do
+    {:ok, servers, _, _} = select_servers(topology, :read, opts)
+    Enum.any?(servers)
   end
 
   def has_writable_server?(topology) do

--- a/test/mongo/topology_description_test.exs
+++ b/test/mongo/topology_description_test.exs
@@ -16,12 +16,16 @@ defmodule Mongo.TopologyDescriptionTest do
     assert {:ok, single_server, false, false} ==
              TopologyDescription.select_servers(single(), :write)
 
+    assert TopologyDescription.has_readable_server?(single(), opts)
+
     opts = [
       read_preference: ReadPreference.defaults(%{mode: :nearest})
     ]
 
     assert {:ok, single_server, true, false} ==
              TopologyDescription.select_servers(single(), :read, opts)
+
+    assert TopologyDescription.has_readable_server?(single(), opts)
   end
 
   test "replica set server selection" do
@@ -35,6 +39,10 @@ defmodule Mongo.TopologyDescriptionTest do
     assert {:ok, List.delete(all_hosts, master), true, false} ==
              TopologyDescription.select_servers(repl_set_with_master(), :read, opts)
 
+    assert TopologyDescription.has_readable_server?(repl_set_with_master(), opts)
+    assert !TopologyDescription.has_readable_server?(repl_set_only_master(), opts)
+    assert TopologyDescription.has_readable_server?(repl_set_no_master(), opts)
+
     opts = [
       read_preference: ReadPreference.defaults(%{mode: :primary})
     ]
@@ -42,6 +50,10 @@ defmodule Mongo.TopologyDescriptionTest do
     assert {:ok, [master], true, false} ==
              TopologyDescription.select_servers(repl_set_with_master(), :read, opts)
 
+    assert TopologyDescription.has_readable_server?(repl_set_with_master(), opts)
+    assert TopologyDescription.has_readable_server?(repl_set_only_master(), opts)
+    assert !TopologyDescription.has_readable_server?(repl_set_no_master(), opts)
+
     opts = [
       read_preference: ReadPreference.defaults(%{mode: :primary_preferred})
     ]
@@ -49,12 +61,12 @@ defmodule Mongo.TopologyDescriptionTest do
     assert {:ok, [master], true, false} ==
              TopologyDescription.select_servers(repl_set_with_master(), :read, opts)
 
-    opts = [
-      read_preference: ReadPreference.defaults(%{mode: :primary_preferred})
-    ]
-
     assert {:ok, List.delete(all_hosts, master), true, false} ==
              TopologyDescription.select_servers(repl_set_no_master(), :read, opts)
+
+    assert TopologyDescription.has_readable_server?(repl_set_with_master(), opts)
+    assert TopologyDescription.has_readable_server?(repl_set_only_master(), opts)
+    assert TopologyDescription.has_readable_server?(repl_set_no_master(), opts)
 
     opts = [
       read_preference: ReadPreference.defaults(%{mode: :nearest})
@@ -63,12 +75,20 @@ defmodule Mongo.TopologyDescriptionTest do
     assert {:ok, all_hosts, true, false} ==
              TopologyDescription.select_servers(repl_set_with_master(), :read, opts)
 
+    assert TopologyDescription.has_readable_server?(repl_set_with_master(), opts)
+    assert TopologyDescription.has_readable_server?(repl_set_only_master(), opts)
+    assert TopologyDescription.has_readable_server?(repl_set_no_master(), opts)
+
     opts = [
       read_preference: ReadPreference.defaults(%{mode: :secondary})
     ]
 
     assert {:ok, List.delete(all_hosts, master), true, false} ==
              TopologyDescription.select_servers(repl_set_no_master(), :read, opts)
+
+    assert TopologyDescription.has_readable_server?(repl_set_with_master(), opts)
+    assert !TopologyDescription.has_readable_server?(repl_set_only_master(), opts)
+    assert TopologyDescription.has_readable_server?(repl_set_no_master(), opts)
 
     opts = [
       read_preference: ReadPreference.defaults(%{mode: :secondary_preferred})
@@ -83,12 +103,20 @@ defmodule Mongo.TopologyDescriptionTest do
     assert {:ok, List.delete(all_hosts, master), true, false} ==
              TopologyDescription.select_servers(repl_set_no_master(), :read, opts)
 
+    assert TopologyDescription.has_readable_server?(repl_set_with_master(), opts)
+    assert TopologyDescription.has_readable_server?(repl_set_only_master(), opts)
+    assert TopologyDescription.has_readable_server?(repl_set_no_master(), opts)
+
     opts = [
       read_preference: ReadPreference.defaults(%{mode: :nearest})
     ]
 
     assert {:ok, all_hosts, true, false} ==
              TopologyDescription.select_servers(repl_set_no_master(), :read, opts)
+
+    assert TopologyDescription.has_readable_server?(repl_set_with_master(), opts)
+    assert TopologyDescription.has_readable_server?(repl_set_only_master(), opts)
+    assert TopologyDescription.has_readable_server?(repl_set_no_master(), opts)
   end
 
   test "Simplified server selection" do
@@ -100,5 +128,7 @@ defmodule Mongo.TopologyDescriptionTest do
 
     assert {:ok, single_server, true, false} ==
              TopologyDescription.select_servers(single(), :read, opts)
+
+    assert TopologyDescription.has_readable_server?(single(), opts)
   end
 end


### PR DESCRIPTION
This PR adds `has_readable_server?` method to `TopologyDescription`.

The previous implementation returned always `true` which wasn't right in many cases.