### PR TITLE
Backport: Fixes time units atoms deprecation warnings in v0.4.x

### DIFF
--- a/lib/bson/decoder.ex
+++ b/lib/bson/decoder.ex
@@ -69,7 +69,7 @@ defmodule BSON.Decoder do
   end
 
   defp type(@type_datetime, <<unix_ms::int64, rest::binary>>) do
-    {DateTime.from_unix!(unix_ms, :milliseconds), rest}
+    {DateTime.from_unix!(unix_ms, :millisecond), rest}
   end
 
   defp type(@type_undefined, rest) do

--- a/lib/bson/encoder.ex
+++ b/lib/bson/encoder.ex
@@ -26,7 +26,7 @@ defmodule BSON.Encoder do
     do: value
 
   def encode(%DateTime{} = datetime) do
-    unix_ms = DateTime.to_unix(datetime, :milliseconds)
+    unix_ms = DateTime.to_unix(datetime, :millisecond)
     <<unix_ms::int64>>
   end
 

--- a/lib/mongo/monitor.ex
+++ b/lib/mongo/monitor.ex
@@ -86,7 +86,7 @@ defmodule Mongo.Monitor do
   ## Private functions
 
   defp check(state) do
-    diff = :os.system_time(:millisecond) - state.server_description.last_update_time
+    diff = :os.system_time(:milli_seconds) - state.server_description.last_update_time
     if diff < @min_heartbeat_frequency_ms do
       {:noreply, state, diff}
     else

--- a/lib/mongo/monitor.ex
+++ b/lib/mongo/monitor.ex
@@ -86,7 +86,7 @@ defmodule Mongo.Monitor do
   ## Private functions
 
   defp check(state) do
-    diff = :os.system_time(:milli_seconds) - state.server_description.last_update_time
+    diff = :os.system_time(:millisecond) - state.server_description.last_update_time
     if diff < @min_heartbeat_frequency_ms do
       {:noreply, state, diff}
     else
@@ -107,8 +107,8 @@ defmodule Mongo.Monitor do
         {:error, e}
     end
     finish_time = System.monotonic_time
-    rtt = System.convert_time_unit(finish_time - start_time, :native, :milliseconds)
-    finish_time = System.convert_time_unit(finish_time, :native, :milliseconds)
+    rtt = System.convert_time_unit(finish_time - start_time, :native, :millisecond)
+    finish_time = System.convert_time_unit(finish_time, :native, :millisecond)
 
     {result, finish_time, rtt}
   end

--- a/lib/mongo/topology.ex
+++ b/lib/mongo/topology.ex
@@ -27,7 +27,7 @@ defmodule Mongo.Topology do
   end
 
   def wait_for_connection(pid, timeout, start_time) do
-    timeout = timeout - System.convert_time_unit(System.monotonic_time - start_time, :native, :milliseconds)
+    timeout = timeout - System.convert_time_unit(System.monotonic_time - start_time, :native, :millisecond)
 
     try do
       case GenServer.call(pid, :wait_for_connection, timeout) do

--- a/test/bson_test.exs
+++ b/test/bson_test.exs
@@ -45,7 +45,7 @@ defmodule BSONTest do
   @map11 %{"g" => true}
   @bin11 <<9, 0, 0, 0, 8, 103, 0, 1, 0>>
 
-  @map12 %{"h" => DateTime.from_unix!(12345, :milliseconds)}
+  @map12 %{"h" => DateTime.from_unix!(12345, :millisecond)}
   @bin12 <<16, 0, 0, 0, 9, 104, 0, 57, 48, 0, 0, 0, 0, 0, 0, 0>>
 
   @map13 %{"i" => nil}


### PR DESCRIPTION
Backport of https://github.com/ankhers/mongodb/pull/270 into v0.4.x.
> Plural time units are deprecated since Elixir 1.8.0 as singular ones are supported since v1.4.0.

I introduced this backport because I can't just upgrade to v0.5.x b/o mongodb_ecto.