### PR TITLE
Custom Mongo.Encoder protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,48 @@ for document keys but will only decode to strings.
 
 ² BSON symbols can only be decoded.
 
+### Writing your own encoding info
+
+If you want to write a custom struct to your mongo collection - you can do that
+by implementing `Mongo.Encoder` protocol for your class. The output should be a map,
+which will be passed to the Mongo database.
+
+Example:
+
+```elixir
+defmodule CustomStruct do
+  @fields [:a, :b, :c, :id]
+  @enforce_keys @fields
+  defstruct @fields
+
+  defimpl Mongo.Encoder do
+    def encode(%{a: a, b: b, id: id}) do
+      %{
+        _id: id,
+        a: a,
+        b: b,
+        custom_encoded: true
+      }
+    end
+  end
+end
+```
+
+So, given the struct:
+```elixir
+%CustomStruct{a: 10, b: 20, c: 30, id: "5ef27e73d2a57d358f812001"}
+```
+
+it will be written to database, as:
+```json
+{
+  "a": 10,
+  "b": 20,
+  "custom_encoded": true,
+  "_id": "5ef27e73d2a57d358f812001"
+}
+```
+
 ## Usage
 
 ### Installation:

--- a/lib/bson/encoder.ex
+++ b/lib/bson/encoder.ex
@@ -117,7 +117,12 @@ defmodule BSON.Encoder do
         {key, value}, {_, acc} ->
           {key_type, key} = key(key)
           type = type(value)
-          value = encode(value)
+
+          value =
+            if Mongo.Encoder.impl_for(value),
+              do: value |> Mongo.Encoder.encode() |> encode(),
+              else: value |> encode()
+
           {key_type, [acc, type, key, value]}
       end)
 

--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -1197,10 +1197,10 @@ defmodule Mongo do
   defp assert_single_doc!([{_, _} | _]), do: :ok
 
   defp assert_single_doc!(other) do
-    raise ArgumentError, "expected single document, got: #{inspect(other)}"
+    unless Mongo.Encoder.impl_for(other), do: raise(ArgumentError, "expected single document, got: #{inspect(other)}"), else: :ok
   end
 
-  defp assert_many_docs!([first | _]) when not is_tuple(first), do: :ok
+  defp assert_many_docs!(docs) when is_list(docs), do: Enum.all?(docs, &assert_single_doc!/1) && :ok
 
   defp assert_many_docs!(other) do
     raise ArgumentError, "expected list of documents, got: #{inspect(other)}"
@@ -1212,6 +1212,7 @@ defmodule Mongo do
 
   defp assign_ids(list) when is_list(list) do
     list
+    |> Enum.map(&Mongo.Encoder.encode/1)
     |> Enum.map(&assign_id/1)
     |> Enum.unzip()
   end

--- a/lib/mongo/encoder.ex
+++ b/lib/mongo/encoder.ex
@@ -1,0 +1,8 @@
+defprotocol Mongo.Encoder do
+  @spec encode(t) :: map()
+  def encode(value)
+end
+
+defimpl Mongo.Encoder, for: Map do
+  def encode(v), do: v
+end

--- a/lib/mongo/encoder.ex
+++ b/lib/mongo/encoder.ex
@@ -1,6 +1,7 @@
 defprotocol Mongo.Encoder do
   @fallback_to_any false
 
+  @spec encode(t) :: map()
   def encode(value)
 end
 

--- a/lib/mongo/encoder.ex
+++ b/lib/mongo/encoder.ex
@@ -1,5 +1,6 @@
 defprotocol Mongo.Encoder do
-  @spec encode(t) :: map()
+  @fallback_to_any false
+
   def encode(value)
 end
 

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,8 @@ defmodule Mongodb.Mixfile do
         flags: [:underspecs, :unknown, :unmatched_returns],
         plt_add_apps: [:logger, :connection, :db_connection, :mix, :elixir, :ssl, :public_key],
         plt_add_deps: :transitive
-      ]
+      ],
+      consolidate_protocols: Mix.env() != :test
     ]
   end
 

--- a/test/mongo/encoder_test.exs
+++ b/test/mongo/encoder_test.exs
@@ -8,7 +8,8 @@ defmodule Mongo.EncoderTest do
                hostname: "localhost",
                database: "mongodb_test",
                username: "mongodb_user",
-               password: "mongodb_user"
+               password: "mongodb_user",
+               show_sensitive_data_on_connection_error: true
              )
 
     pid
@@ -37,31 +38,41 @@ defmodule Mongo.EncoderTest do
     end
   end
 
-
   test "insert encoded struct with protocol" do
     pid = connect_auth()
     coll = unique_name()
-    {:ok, conn, _, _} = Mongo.select_server(pid, :read)
+    {:ok, conn, _, _} = Mongo.select_server(pid, :write)
 
     struct_to_insert = %CustomStruct{a: 10, b: 20, c: 30, id: "5ef27e73d2a57d358f812001"}
 
     assert {:ok, _} = Mongo.insert_one(pid, coll, struct_to_insert, [])
 
-    assert {:ok, %{cursor_id: 0, from: 0, num: 1, docs: [%{"a" => 10, "b" => 20, "custom_encoded" => true, "_id" => "5ef27e73d2a57d358f812001"}]}} =
-             Mongo.raw_find(conn, coll, %{}, nil, skip: 0)
+    assert {:ok,
+            %{
+              cursor_id: 0,
+              from: 0,
+              num: 1,
+              docs: [
+                %{
+                  "a" => 10,
+                  "b" => 20,
+                  "custom_encoded" => true,
+                  "_id" => "5ef27e73d2a57d358f812001"
+                }
+              ]
+            }} = Mongo.raw_find(conn, coll, %{}, nil, skip: 0)
   end
 
   test "insert encoded struct without protocol" do
     pid = connect_auth()
     coll = unique_name()
-    {:ok, conn, _, _} = Mongo.select_server(pid, :read)
+    {:ok, conn, _, _} = Mongo.select_server(pid, :write)
 
-    struct_to_insert = %CustomStructWithoutProtocol{a: 10, b: 20, c: 30, id: "5ef27e73d2a57d358f812001"}
+    struct_to_insert = %CustomStructWithoutProtocol{a: 10, b: 20, c: 30, id: "x"}
 
-    assert {:ok, _} = Mongo.insert_one(pid, coll, struct_to_insert, [])
-
-    assert {:ok, %{cursor_id: 0, from: 0, num: 1, docs: [%{"a" => 10, "b" => 20, "custom_encoded" => true, "_id" => "5ef27e73d2a57d358f812001"}]}} =
-             Mongo.raw_find(conn, coll, %{}, nil, skip: 0)
+    assert_raise Protocol.UndefinedError, fn ->
+      Mongo.insert_one(pid, coll, struct_to_insert, [])
+    end
   end
 
   defimpl Mongo.Encoder, for: Function do
@@ -71,13 +82,82 @@ defmodule Mongo.EncoderTest do
   test "insert encoded function to db" do
     pid = connect_auth()
     coll = unique_name()
-    {:ok, conn, _, _} = Mongo.select_server(pid, :read)
+    {:ok, conn, _, _} = Mongo.select_server(pid, :write)
 
     fun_to_insert = & &1
 
     assert {:ok, _} = Mongo.insert_one(pid, coll, fun_to_insert, [])
 
-    assert {:ok, %{cursor_id: 0, from: 0, num: 1, docs: [%{"fun" => true, "_id" => "5ef27e73d2a57d358f812002"}]}} =
-             Mongo.raw_find(conn, coll, %{}, nil, skip: 0)
+    assert {:ok,
+            %{
+              cursor_id: 0,
+              from: 0,
+              num: 1,
+              docs: [%{"fun" => true, "_id" => "5ef27e73d2a57d358f812002"}]
+            }} = Mongo.raw_find(conn, coll, %{}, nil, skip: 0)
+  end
+
+  test "update with encoded struct in db with protocol" do
+    pid = connect_auth()
+    coll = unique_name()
+    {:ok, conn, _, _} = Mongo.select_server(pid, :write)
+
+    struct_to_insert = %CustomStruct{a: 10, b: 20, c: 30, id: "5ef27e73d2a57d358f812001"}
+
+    assert {:ok, _} = Mongo.insert_one(pid, coll, struct_to_insert, [])
+
+    struct_to_change = %CustomStruct{a: 100, b: 200, c: 300, id: "5ef27e73d2a57d358f812001"}
+
+    assert {:ok, _} =
+             Mongo.update_one(pid, coll, %{_id: "5ef27e73d2a57d358f812001"}, %{
+               "$set": struct_to_change
+             })
+
+    assert {:ok,
+            %{
+              cursor_id: 0,
+              from: 0,
+              num: 1,
+              docs: [
+                %{
+                  "a" => 100,
+                  "b" => 200,
+                  "custom_encoded" => true,
+                  "_id" => "5ef27e73d2a57d358f812001"
+                }
+              ]
+            }} = Mongo.raw_find(conn, coll, %{}, nil, skip: 0)
+  end
+
+  test "upsert with encoded struct in db with protocol" do
+    pid = connect_auth()
+    coll = unique_name()
+    {:ok, conn, _, _} = Mongo.select_server(pid, :write)
+
+    struct_to_change = %CustomStruct{a: 100, b: 200, c: 300, id: "5ef27e73d2a57d358f812001"}
+
+    assert {:ok, _} =
+             Mongo.update_one(
+               pid,
+               coll,
+               %{_id: "5ef27e73d2a57d358f812001"},
+               %{"$set": struct_to_change},
+               upsert: true
+             )
+
+    assert {:ok,
+            %{
+              cursor_id: 0,
+              from: 0,
+              num: 1,
+              docs: [
+                %{
+                  "a" => 100,
+                  "b" => 200,
+                  "custom_encoded" => true,
+                  "_id" => "5ef27e73d2a57d358f812001"
+                }
+              ]
+            }} = Mongo.raw_find(conn, coll, %{}, nil, skip: 0)
   end
 end

--- a/test/mongo/encoder_test.exs
+++ b/test/mongo/encoder_test.exs
@@ -8,8 +8,7 @@ defmodule Mongo.EncoderTest do
                hostname: "localhost",
                database: "mongodb_test",
                username: "mongodb_user",
-               password: "mongodb_user",
-               show_sensitive_data_on_connection_error: true
+               password: "mongodb_user"
              )
 
     pid

--- a/test/mongo/encoder_test.exs
+++ b/test/mongo/encoder_test.exs
@@ -1,0 +1,83 @@
+defmodule Mongo.EncoderTest do
+  use MongoTest.Case, async: false
+  alias Mongo
+
+  defp connect_auth do
+    assert {:ok, pid} =
+             Mongo.start_link(
+               hostname: "localhost",
+               database: "mongodb_test",
+               username: "mongodb_user",
+               password: "mongodb_user"
+             )
+
+    pid
+  end
+
+  defmodule CustomStructWithoutProtocol do
+    @fields [:a, :b, :c, :id]
+    @enforce_keys @fields
+    defstruct @fields
+  end
+
+  defmodule CustomStruct do
+    @fields [:a, :b, :c, :id]
+    @enforce_keys @fields
+    defstruct @fields
+
+    defimpl Mongo.Encoder do
+      def encode(%{a: a, b: b, id: id}) do
+        %{
+          _id: id,
+          a: a,
+          b: b,
+          custom_encoded: true
+        }
+      end
+    end
+  end
+
+
+  test "insert encoded struct with protocol" do
+    pid = connect_auth()
+    coll = unique_name()
+    {:ok, conn, _, _} = Mongo.select_server(pid, :read)
+
+    struct_to_insert = %CustomStruct{a: 10, b: 20, c: 30, id: "5ef27e73d2a57d358f812001"}
+
+    assert {:ok, _} = Mongo.insert_one(pid, coll, struct_to_insert, [])
+
+    assert {:ok, %{cursor_id: 0, from: 0, num: 1, docs: [%{"a" => 10, "b" => 20, "custom_encoded" => true, "_id" => "5ef27e73d2a57d358f812001"}]}} =
+             Mongo.raw_find(conn, coll, %{}, nil, skip: 0)
+  end
+
+  test "insert encoded struct without protocol" do
+    pid = connect_auth()
+    coll = unique_name()
+    {:ok, conn, _, _} = Mongo.select_server(pid, :read)
+
+    struct_to_insert = %CustomStructWithoutProtocol{a: 10, b: 20, c: 30, id: "5ef27e73d2a57d358f812001"}
+
+    assert {:ok, _} = Mongo.insert_one(pid, coll, struct_to_insert, [])
+
+    assert {:ok, %{cursor_id: 0, from: 0, num: 1, docs: [%{"a" => 10, "b" => 20, "custom_encoded" => true, "_id" => "5ef27e73d2a57d358f812001"}]}} =
+             Mongo.raw_find(conn, coll, %{}, nil, skip: 0)
+  end
+
+  defimpl Mongo.Encoder, for: Function do
+    def encode(_), do: %{fun: true, _id: "5ef27e73d2a57d358f812002"}
+  end
+
+  test "insert encoded function to db" do
+    pid = connect_auth()
+    coll = unique_name()
+    {:ok, conn, _, _} = Mongo.select_server(pid, :read)
+
+    fun_to_insert = & &1
+
+    assert {:ok, _} = Mongo.insert_one(pid, coll, fun_to_insert, [])
+
+    assert {:ok, %{cursor_id: 0, from: 0, num: 1, docs: [%{"fun" => true, "_id" => "5ef27e73d2a57d358f812002"}]}} =
+             Mongo.raw_find(conn, coll, %{}, nil, skip: 0)
+  end
+end


### PR DESCRIPTION
Hi,

This PR adds a feature: `Mongo.Encoder` protocol.

In our project, we very often spot a case when we need to insert map, generated from some struct into the mongo database. With that PR, instead of writing a custom glue code, we can simply implement `Mongo.Encoder` protocol. Which in turns results in clearer, more idiomatic Elixir code.