### PR TITLE
support appName option

### DIFF
--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -6,6 +6,7 @@ defmodule Mongo.UrlParser do
   # https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options
   @mongo_options %{
     # Path options
+    "appName" => :string,
     "username" => :string,
     "password" => :string,
     "database" => :string,

--- a/test/mongo/url_parser_test.exs
+++ b/test/mongo/url_parser_test.exs
@@ -83,5 +83,18 @@ defmodule Mongo.UrlParserTest do
                ]
       end
     end
+
+    test "appName option" do
+      url = "mongodb://USERNAME:PASSWORD@HOST:PORT/DATABASE?ssl=true&replicaSet=globaldb&appName=APP"
+      assert UrlParser.parse_url(url: url) == [
+        username: "USERNAME",
+        password: "PASSWORD",
+        database: "DATABASE",
+        app_name: "APP",
+        set_name: "globaldb",
+        ssl: true,
+        seeds: ["HOST:PORT"]
+      ]
+    end
   end
 end


### PR DESCRIPTION
Microsoft has stated that support for the `appName` connection option is required to use CosmosDB.
See https://docs.microsoft.com/en-us/azure/cosmos-db/mongodb-troubleshoot.
According to https://docs.mongodb.com/manual/reference/connection-string/#urioption.appName, this option was new in version 4.0. 

This PR adds some support for the `appName` connection option in the hope that any additional work that is needed can be added by a more experienced maintainer.