### PR TITLE
Fix Elixir 1.11 dependency warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Mongodb.Mixfile do
     [
       mod: {Mongo.App, []},
       env: [],
-      extra_applications: [:crytpo, :logger, :ssl],
+      extra_applications: [:crypto, :logger, :ssl],
       registered: [
         Mongo.PBKDF2Cache,
         Mongo.Session.Supervisor,

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Mongodb.Mixfile do
     [
       mod: {Mongo.App, []},
       env: [],
-      extra_applications: [:logger],
+      extra_applications: [:crytpo, :logger, :ssl],
       registered: [
         Mongo.PBKDF2Cache,
         Mongo.Session.Supervisor,


### PR DESCRIPTION
Example warnings (there are other occurrences):

```
warning: :ssl.getopts/2 defined in application :ssl is used by the current application but the current application does not directly depend on :ssl. To fix this, you must do one of:

  1. If :ssl is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ssl is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ssl, you may optionally skip this warning by adding [xref: [exclude: :ssl] to your "def project" in mix.exs

  lib/mongo/protocol.ex:394: Mongo.Protocol.getopts/3
```

and

```
warning: :crypto.strong_rand_bytes/1 defined in application :crypto is used by the current application but the current application does not directly depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: :crypto] to your "def project" in mix.exs

  lib/mongo/auth/scram.ex:96: Mongo.Auth.SCRAM.nonce/0
```