### PR TITLE
Fix System.stacktrace/0 is deprecated warning

### DIFF
--- a/lib/mongo/session.ex
+++ b/lib/mongo/session.ex
@@ -90,7 +90,7 @@ defmodule Mongo.Session do
   rescue
     exception ->
       _ = abort_transaction(pid)
-      reraise exception, System.stacktrace()
+      reraise exception, __STACKTRACE__
   else
     val ->
       with :ok <- commit_transaction(pid), do: {:ok, val}


### PR DESCRIPTION
fixes #352

Warning: This requires Elixir 1.7.0. This repo currently supports Elixir 1.5 (as defined in mix.exs).
See https://hexdocs.pm/elixir/Kernel.SpecialForms.html#__STACKTRACE__/0

This also ensures that we'll support the next Elixir version