### PR TITLE
Replace hmac/3 calls with mac/4 calls

### DIFF
--- a/lib/mongo/auth/scram.ex
+++ b/lib/mongo/auth/scram.ex
@@ -82,16 +82,16 @@ defmodule Mongo.Auth.SCRAM do
   end
 
   defp generate_proof(salted_password, auth_message) do
-    client_key = :crypto.hmac(:sha, salted_password, "Client Key")
+    client_key = :crypto.mac(:hmac, :sha, salted_password, "Client Key")
     stored_key = :crypto.hash(:sha, client_key)
-    signature = :crypto.hmac(:sha, stored_key, auth_message)
+    signature = :crypto.mac(:hmac, :sha, stored_key, auth_message)
     client_proof = xor_keys(client_key, signature, "")
     "p=#{Base.encode64(client_proof)}"
   end
 
   defp generate_signature(salted_password, auth_message) do
-    server_key = :crypto.hmac(:sha, salted_password, "Server Key")
-    :crypto.hmac(:sha, server_key, auth_message)
+    server_key = :crypto.mac(:hmac, :sha, salted_password, "Server Key")
+    :crypto.mac(:hmac, :sha, server_key, auth_message)
   end
 
   defp xor_keys("", "", result),

--- a/lib/mongo/pbkdf2.ex
+++ b/lib/mongo/pbkdf2.ex
@@ -65,6 +65,6 @@ defmodule Mongo.PBKDF2 do
   end
 
   defp mac_fun(digest, secret) do
-    &:crypto.hmac(digest, secret, &1)
+    &:crypto.mac(:hmac, digest, secret, &1)
   end
 end


### PR DESCRIPTION
hmac/3 is now obsolete and the recommended function is mac/4