### PR TITLE
Bug 1402675 add support for tls in url parser

### DIFF
--- a/lib/mongo/auth/scram.ex
+++ b/lib/mongo/auth/scram.ex
@@ -82,16 +82,23 @@ defmodule Mongo.Auth.SCRAM do
   end
 
   defp generate_proof(salted_password, auth_message) do
-    client_key = :crypto.hmac(:sha, salted_password, "Client Key")
+    client_key = hmac(salted_password, "Client Key")
     stored_key = :crypto.hash(:sha, client_key)
-    signature = :crypto.hmac(:sha, stored_key, auth_message)
+    signature = hmac(stored_key, auth_message)
     client_proof = xor_keys(client_key, signature, "")
     "p=#{Base.encode64(client_proof)}"
   end
 
+  defp hmac(key, data) do
+    case Kernel.function_exported?(:crypto, :mac, 3) do
+      true -> :crypto.mac(:hmac, :sha, key, data)
+      false -> :crypto.hmac(:sha, key, data)
+    end
+  end
+
   defp generate_signature(salted_password, auth_message) do
-    server_key = :crypto.hmac(:sha, salted_password, "Server Key")
-    :crypto.hmac(:sha, server_key, auth_message)
+    server_key = hmac(salted_password, "Server Key")
+    hmac(server_key, auth_message)
   end
 
   defp xor_keys("", "", result),

--- a/lib/mongo/pbkdf2.ex
+++ b/lib/mongo/pbkdf2.ex
@@ -65,6 +65,9 @@ defmodule Mongo.PBKDF2 do
   end
 
   defp mac_fun(digest, secret) do
-    &:crypto.hmac(digest, secret, &1)
+    case Kernel.function_exported?(:crypto, :mac, 3) do
+      true -> &:crypto.mac(:hmac, digest, secret, &1)
+      false -> &:crypto.hmac(digest, secret, &1)
+    end
   end
 end

--- a/lib/mongo/protocol.ex
+++ b/lib/mongo/protocol.ex
@@ -40,7 +40,7 @@ defmodule Mongo.Protocol do
       auth_mechanism: opts[:auth_mechanism] || nil,
       connection_type: Keyword.fetch!(opts, :connection_type),
       topology_pid: Keyword.fetch!(opts, :topology_pid),
-      ssl: opts[:ssl] || false,
+      ssl: opts[:ssl] || opts[:tls] || false,
       status: :idle,
       session: nil
     }

--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -41,6 +41,7 @@ defmodule Mongo.UrlParser do
     "serverSelectionTryOnce" => ["true", "false"],
     "heartbeatFrequencyMS" => :number,
     "retryWrites" => ["true", "false"],
+    "tls" => ["true", "false"],
     "uuidRepresentation" => ["standard", "csharpLegacy", "javaLegacy", "pythonLegacy"],
     # Elixir Driver options
     "type" => ["unknown", "single", "replicaSetNoPrimary", "sharded"]

--- a/test/mongo/url_parser_test.exs
+++ b/test/mongo/url_parser_test.exs
@@ -18,7 +18,7 @@ defmodule Mongo.UrlParserTest do
       assert password = "2yPK}Bzj|qE($^1JDdk4J42*&4lLgV%C"
     end
 
-    test "cluster url" do
+    test "cluster url with ssl" do
       url =
         "mongodb://user:password@seed1.domain.com:27017,seed2.domain.com:27017,seed3.domain.com:27017/db_name?ssl=true&replicaSet=set-name&authSource=admin&maxPoolSize=5"
 
@@ -30,6 +30,26 @@ defmodule Mongo.UrlParserTest do
                auth_source: "admin",
                set_name: "set-name",
                ssl: true,
+               seeds: [
+                 "seed1.domain.com:27017",
+                 "seed2.domain.com:27017",
+                 "seed3.domain.com:27017"
+               ]
+             ]
+    end
+
+    test "cluster url with tls" do
+      url =
+        "mongodb://user:password@seed1.domain.com:27017,seed2.domain.com:27017,seed3.domain.com:27017/db_name?tls=true&replicaSet=set-name&authSource=admin&maxPoolSize=5"
+
+      assert UrlParser.parse_url(url: url) == [
+               username: "user",
+               password: "password",
+               database: "db_name",
+               pool_size: 5,
+               auth_source: "admin",
+               set_name: "set-name",
+               tls: true,
                seeds: [
                  "seed1.domain.com:27017",
                  "seed2.domain.com:27017",


### PR DESCRIPTION
Mongo database connections could not be established when 'tls=true' was included in connection strings. With this change, the presence of 'tls=true' is the same as 'ssl=true'.